### PR TITLE
Add custom ACME server feature in backend

### DIFF
--- a/src/mod/acme/acme.go
+++ b/src/mod/acme/acme.go
@@ -95,7 +95,7 @@ func (a *ACMEHandler) ObtainCert(domains []string, certificateName string, email
 
 	// if not custom ACME url, load it from ca.json
 	if caName == "custom" {
-		log.Println("[INFO] Using Custom ACME" + caUrl + " for CA Directory URL")
+		log.Println("[INFO] Using Custom ACME " + caUrl + " for CA Directory URL")
 	} else {
 		caLinkOverwrite, err := loadCAApiServerFromName(caName)
 		if err == nil {
@@ -104,7 +104,7 @@ func (a *ACMEHandler) ObtainCert(domains []string, certificateName string, email
 		} else {
 			// (caName == "" || caUrl == "") will use default acme
 			config.CADirURL = a.DefaultAcmeServer
-			log.Println("[INFO] Using Default ACME" + a.DefaultAcmeServer + " for CA Directory URL")
+			log.Println("[INFO] Using Default ACME " + a.DefaultAcmeServer + " for CA Directory URL")
 		}
 	}
 

--- a/src/mod/acme/autorenew.go
+++ b/src/mod/acme/autorenew.go
@@ -3,6 +3,7 @@ package acme
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log"
 	"net/http"
 	"net/mail"
@@ -355,7 +356,16 @@ func (a *AutoRenewer) renewExpiredDomains(certs []*ExpiredCerts) ([]string, erro
 		log.Println("Renewing " + expiredCert.Filepath + " (Might take a few minutes)")
 		fileName := filepath.Base(expiredCert.Filepath)
 		certName := fileName[:len(fileName)-len(filepath.Ext(fileName))]
-		_, err := a.AcmeHandler.ObtainCert(expiredCert.Domains, certName, a.RenewerConfig.Email, expiredCert.CA)
+
+		// Load certificate info for ACME detail
+		certInfoFilename := fmt.Sprintf("%s/%s.json", filepath.Dir(expiredCert.Filepath), certName)
+		certInfo, err := loadCertInfoJSON(certInfoFilename)
+		if err != nil {
+			log.Printf("Renew %s certificate error, can't get the ACME detail for cert: %v, using default ACME", certName, err)
+			certInfo = &CertificateInfoJSON{}
+		}
+
+		_, err = a.AcmeHandler.ObtainCert(expiredCert.Domains, certName, a.RenewerConfig.Email, certInfo.AcmeName, certInfo.AcmeUrl)
 		if err != nil {
 			log.Println("Renew " + fileName + "(" + strings.Join(expiredCert.Domains, ",") + ") failed: " + err.Error())
 		} else {

--- a/src/web/snippet/acme.html
+++ b/src/web/snippet/acme.html
@@ -109,9 +109,14 @@
           <div class="item" data-value="Let's Encrypt">Let's Encrypt</div>
           <div class="item" data-value="Buypass">Buypass</div>
           <div class="item" data-value="ZeroSSL">ZeroSSL</div>
+          <div class="item" data-value="Custom ACME Server">Custom ACME Server</div>
           <!-- <div class="item" data-value="Google">Google</div> -->
         </div>
       </div>
+    </div>
+    <div class="field" id="customca" style="display:none;">
+      <label>ACME Server URL</label>
+      <input id="caurl" type="text" placeholder="https://example.com/acme/dictionary">
     </div>
     <button id="obtainButton" class="ui basic button" type="submit"><i class="yellow refresh icon"></i> Renew Certificate</button>
   </div>
@@ -295,6 +300,14 @@
       obtainCertificate();
     });
 
+    $("input[name=ca]").on('change', function() {
+      if(this.value == "Custom ACME Server") {
+        $("#customca").show();
+      } else {
+        $("#customca").hide();
+      }
+    })
+
     // Obtain certificate from API
     function obtainCertificate() {
       var domains = $("#domainsInput").val();
@@ -316,7 +329,14 @@
         parent.msgbox("Filename cannot be empty for certs containing multiple domains.")
         return;
       }
+      
       var ca = $("#ca").dropdown("get value");
+      var ca_url = "";
+      if (ca == "Custom ACME Server") {
+        ca = "custom";
+        ca_url = $("#caurl").val();
+      }
+
       $.ajax({
         url: "/api/acme/obtainCert",
         method: "GET",
@@ -325,6 +345,7 @@
           filename: filename,
           email: email,
           ca: ca,
+          ca_url: ca_url,
         },
         success: function(response) {
           $("#obtainButton").removeClass("loading").removeClass("disabled");


### PR DESCRIPTION
This PR add custom ACME server feature in backend, but still need frontend support (send `ca_url` parameter when POST to `/api/acme/obtainCert` and `ca` set to `custom`, should be somewhere near `src/web/snippet/acme.html#L320`, if `ca_url` not included, will use `ca` just like before)

this PR's feature will save a json in `./conf/certs/${certificateName}.json` next to the cert key for renew usage, `eab_key_id` and `eab_hmac_key` can be save in json too for future Google ACME server implement.

this also fix Buypass ACME might not be renew correctly, the reason is current implementtion in `src/mod/acme/utils.go#L57` will use Issuer organization sector as `ca.json` key, but current Buypass intermediate certificate use `Buypass AS-983163327` which might cause an issue (but seems ok to LE and ZeroSSL)