### PR TITLE
Use Let's Encrypt as default when not select CA in frontend

### DIFF
--- a/src/web/snippet/acme.html
+++ b/src/web/snippet/acme.html
@@ -344,6 +344,8 @@
       if (ca == "Custom ACME Server") {
         ca = "custom";
         caURL = $("#caURL").val();
+      } else if (ca == "") {
+        ca = "Let's Encrypt";
       }
 
       var skipTLSValue = $("#skipTLSCheckbox")[0].checked;


### PR DESCRIPTION
Quick fix for issue https://github.com/tobychui/zoraxy/issues/61

but should also consider issue https://github.com/tobychui/zoraxy/issues/47 in backend