### PR TITLE
Fix the out of range problem when certificate auto renew 

### DIFF
--- a/src/mod/acme/autorenew.go
+++ b/src/mod/acme/autorenew.go
@@ -40,7 +40,6 @@ type AutoRenewer struct {
 type ExpiredCerts struct {
 	Domains  []string
 	Filepath string
-	CA       string
 }
 
 // Create an auto renew agent, require config filepath and auto scan & renew interval (seconds)
@@ -347,8 +346,14 @@ func (a *AutoRenewer) renewExpiredDomains(certs []*ExpiredCerts) ([]string, erro
 		certInfoFilename := fmt.Sprintf("%s/%s.json", filepath.Dir(expiredCert.Filepath), certName)
 		certInfo, err := loadCertInfoJSON(certInfoFilename)
 		if err != nil {
-			log.Printf("Renew %s certificate error, can't get the ACME detail for cert: %v, using default ACME", certName, err)
-			certInfo = &CertificateInfoJSON{}
+			log.Printf("Renew %s certificate error, can't get the ACME detail for cert: %v, trying org section as ca", certName, err)
+
+			if CAName, extractErr := ExtractIssuerNameFromPEM(expiredCert.Filepath); extractErr != nil {
+				log.Printf("extract issuer name for cert error: %v, using default ca", extractErr)
+				certInfo = &CertificateInfoJSON{}
+			} else {
+				certInfo = &CertificateInfoJSON{AcmeName: CAName}
+			}
 		}
 
 		_, err = a.AcmeHandler.ObtainCert(expiredCert.Domains, certName, a.RenewerConfig.Email, certInfo.AcmeName, certInfo.AcmeUrl, certInfo.SkipTLS)

--- a/src/mod/acme/autorenew.go
+++ b/src/mod/acme/autorenew.go
@@ -280,12 +280,6 @@ func (a *AutoRenewer) CheckAndRenewCertificates() ([]string, error) {
 				}
 				if CertExpireSoon(certBytes) || CertIsExpired(certBytes) {
 					//This cert is expired
-					CAName, err := ExtractIssuerName(certBytes)
-					if err != nil {
-						//Maybe self signed. Ignore this
-						log.Println("Unable to extract issuer name for cert " + file.Name())
-						continue
-					}
 
 					DNSName, err := ExtractDomains(certBytes)
 					if err != nil {
@@ -296,7 +290,6 @@ func (a *AutoRenewer) CheckAndRenewCertificates() ([]string, error) {
 
 					expiredCertList = append(expiredCertList, &ExpiredCerts{
 						Filepath: filepath.Join(certFolder, file.Name()),
-						CA:       CAName,
 						Domains:  DNSName,
 					})
 				}
@@ -315,12 +308,6 @@ func (a *AutoRenewer) CheckAndRenewCertificates() ([]string, error) {
 				}
 				if CertExpireSoon(certBytes) || CertIsExpired(certBytes) {
 					//This cert is expired
-					CAName, err := ExtractIssuerName(certBytes)
-					if err != nil {
-						//Maybe self signed. Ignore this
-						log.Println("Unable to extract issuer name for cert " + file.Name())
-						continue
-					}
 
 					DNSName, err := ExtractDomains(certBytes)
 					if err != nil {
@@ -331,7 +318,6 @@ func (a *AutoRenewer) CheckAndRenewCertificates() ([]string, error) {
 
 					expiredCertList = append(expiredCertList, &ExpiredCerts{
 						Filepath: filepath.Join(certFolder, file.Name()),
-						CA:       CAName,
 						Domains:  DNSName,
 					})
 				}

--- a/src/mod/acme/ca.go
+++ b/src/mod/acme/ca.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"log"
+	"strings"
 )
 
 // CA Defination, load from embeded json when startup
@@ -36,9 +37,15 @@ func init() {
 
 // Get the CA ACME server endpoint and error if not found
 func loadCAApiServerFromName(caName string) (string, error) {
+	// handle BuyPass cert org section (Buypass AS-983163327)
+	if strings.HasPrefix(caName, "Buypass AS") {
+		caName = "Buypass"
+	}
+
 	val, ok := caDef.Production[caName]
 	if !ok {
 		return "", errors.New("This CA is not supported")
 	}
+
 	return val, nil
 }

--- a/src/mod/acme/utils.go
+++ b/src/mod/acme/utils.go
@@ -53,6 +53,11 @@ func ExtractIssuerName(certBytes []byte) (string, error) {
 		return "", fmt.Errorf("failed to parse certificate: %v", err)
 	}
 
+	// Check if exist incase some acme server didn't have org section
+	if len(cert.Issuer.Organization) == 0 {
+		return "", fmt.Errorf("cert didn't have org section exist")
+	}
+
 	// Extract the issuer name
 	issuer := cert.Issuer.Organization[0]
 


### PR DESCRIPTION
In some self-hosted acme server, the org section may not exist, and that will cause the auto renew feature error

```
2023/09/12 03:01:14 Check and renew certificates in progress
panic: runtime error: index out of range [0] with length 0

goroutine 67 [running]:
imuslab.com/zoraxy/mod/acme.ExtractIssuerName({0xc01683d500?, 0xc02e4ec240?, 0x0?})
        /opt/zoraxy/source/mod/acme/utils.go:57 +0x10d
imuslab.com/zoraxy/mod/acme.(*AutoRenewer).CheckAndRenewCertificates(0xc03e212240)
        /opt/zoraxy/source/mod/acme/autorenew.go:318 +0x385
imuslab.com/zoraxy/mod/acme.(*AutoRenewer).StartAutoRenewTicker.func1(0xc03e11c240?)
        /opt/zoraxy/source/mod/acme/autorenew.go:118 +0xbf
created by imuslab.com/zoraxy/mod/acme.(*AutoRenewer).StartAutoRenewTicker in goroutine 1
        /opt/zoraxy/source/mod/acme/autorenew.go:111 +0x107
```

and since we use the `certInfo.AcmeName`, `certInfo.AcmeUrl`, `certInfo.SkipTLS` from json file, there is no need to extract `CAName` from certificate anymore