### PR TITLE
Fix spelling mistake

### DIFF
--- a/src/mod/dynamicproxy/templates/forbidden.html
+++ b/src/mod/dynamicproxy/templates/forbidden.html
@@ -39,7 +39,7 @@
                 <h3 style="margin-top: 1em;">403 - Forbidden</h3>
                 <div class="ui divider"></div>
                 <p>You do not have permission to view this directory or page. <br>
-                    This might cause by the region limit setting of this site.</p>
+                    This might be caused by the region limit setting of this site.</p>
                 <div class="ui divider"></div>
                 <div style="text-align: left;">
                     <small>Request time: <span id="reqtime"></span></small><br>

--- a/src/web/components/uptime.html
+++ b/src/web/components/uptime.html
@@ -10,7 +10,7 @@
                 <i class="red remove icon"></i>
                 <div class="content">
                     Uptime Monitoring service is currently unavailable
-                    <div class="sub header">This might cause by an error in cluster communication within the host servers. Please wait for administrator to resolve the issue.</div>
+                    <div class="sub header">This might be caused by an error in cluster communication within the host servers. Please wait for administrator to resolve the issue.</div>
                 </div>
             </h4> 
         </div>


### PR DESCRIPTION
This is a small pr that fixes two spelling mistakes.

- This might cause by the region limit setting of this site. -> This might be caused by the region limit setting of this site.
- This might cause by an error in cluster communication within the host servers. ->  This might be caused by an error in cluster communication within the host servers.