### PR TITLE
add docker containers list to set rules

### DIFF
--- a/src/api.go
+++ b/src/api.go
@@ -222,6 +222,8 @@ func initAPIs() {
 	authRouter.HandleFunc("/api/info/pprof", pprof.Index)
 
 	//If you got APIs to add, append them here
+	// get available docker containers
+	authRouter.HandleFunc("/api/docker/containers", handleDockerContainersList)
 }
 
 // Function to renders Auth related APIs

--- a/src/docker.go
+++ b/src/docker.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/client"
+	"imuslab.com/zoraxy/mod/utils"
+)
+
+func handleDockerContainersList(w http.ResponseWriter, r *http.Request) {
+	apiClient, err := client.NewClientWithOpts(client.WithVersion("1.43"))
+	if err != nil {
+		utils.SendErrorResponse(w, err.Error())
+		return
+	}
+	defer apiClient.Close()
+
+	containers, err := apiClient.ContainerList(context.Background(), container.ListOptions{All: true})
+	if err != nil {
+		utils.SendErrorResponse(w, err.Error())
+		return
+	}
+
+	networks, err := apiClient.NetworkList(context.Background(), types.NetworkListOptions{})
+	if err != nil {
+		utils.SendErrorResponse(w, err.Error())
+		return
+	}
+
+	result := map[string]interface{}{
+		"network":    networks,
+		"containers": containers,
+	}
+
+	js, err := json.Marshal(result)
+	if err != nil {
+		utils.SendErrorResponse(w, err.Error())
+		return
+	}
+
+	utils.SendJSONResponse(w, string(js))
+}

--- a/src/web/components/rules.html
+++ b/src/web/components/rules.html
@@ -26,7 +26,10 @@
                     </div>
                     <div class="field">
                         <label>Target IP Address or Domain Name with port</label>
-                        <input type="text" id="proxyDomain" onchange="autoCheckTls(this.value);">
+                        <div class="ui action input">
+                            <input type="text" id="proxyDomain" onchange="autoCheckTls(this.value);">
+                            <button class="ui icon button" onclick="openDockerContainersList();"><i class="blue docker icon"></i></button>
+                        </div>
                         <small>E.g. 192.168.0.101:8000 or example.com</small>
                     </div>
                     <div class="field">
@@ -401,5 +404,15 @@
         $("#advanceProxyRules").accordion();
         $("#newProxyRuleAccessFilter").parent().dropdown();
     });
+
+    function openDockerContainersList(){
+        showSideWrapper('snippet/dockerContainersList.html');
+    }
+
+    function addContainerItem(item) {
+        $('#rootname').val(item.name);
+        $('#proxyDomain').val(`${item.ip}:${item.port}`)
+        hideSideWrapper(true);
+    }
     
 </script>

--- a/src/web/snippet/dockerContainersList.html
+++ b/src/web/snippet/dockerContainersList.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <!-- Notes: This should be open in its original path-->
+    <link rel="stylesheet" href="../script/semantic/semantic.min.css" />
+    <script src="../script/jquery-3.6.0.min.js"></script>
+    <script src="../script/semantic/semantic.min.js"></script>
+  </head>
+  <body>
+    <br />
+    <div class="ui container">
+      <div class="ui header">
+        <div class="content">
+          List of Docker Containers
+          <div class="sub header">
+            Below is a list of all detected Docker containers currently running
+            on the system.
+          </div>
+        </div>
+      </div>
+      <div id="containersList" class="ui middle aligned divided list active">
+        <div class="ui loader active"></div>
+      </div>
+      <div class="ui horizontal divider"></div>
+      <div id="containersAddedListHeader" class="ui header" hidden>
+        Already added containers:
+      </div>
+      <div
+        id="containersAddedList"
+        class="ui middle aligned divided list"
+      ></div>
+    </div>
+
+    <script>
+      const lines = {};
+      const linesAded = [];
+
+      function getDockerContainers() {
+        const hostRequest = $.get("/api/proxy/list?type=host");
+        const dockerRequest = $.get("/api/docker/containers");
+
+        // Wait for both requests to complete
+        Promise.all([hostRequest, dockerRequest])
+          .then(([hostData, dockerData]) => {
+            if (
+              dockerData.error === undefined &&
+              hostData.error === undefined
+            ) {
+              const { containers, network } = dockerData;
+              const bridge = network.find(({ Name }) => Name === "bridge");
+              const {
+                IPAM: {
+                  Config: [{ Gateway: gateway }],
+                },
+              } = bridge;
+              const existedDomains = hostData.map(({ Domain }) => Domain);
+
+              for (const container of containers) {
+                const {
+                  Ports,
+                  Names: [name],
+                } = container;
+
+                for (const portObject of Ports.filter(
+                  ({ IP: ip }) => ip === "::"
+                )) {
+                  const { IP: ip, PublicPort: port } = portObject;
+                  const key = `${name}-${port}`;
+
+                  if (
+                    existedDomains.some((item) => item === `${gateway}:${port}`)
+                  ) {
+                    linesAded.push({
+                      name: name.replace(/^\//, ""),
+                      ip: gateway,
+                      port,
+                    });
+                  } else if (!lines[key]) {
+                    lines[key] = {
+                      name: name.replace(/^\//, ""),
+                      ip: gateway,
+                      port,
+                    };
+                  }
+                }
+              }
+
+              for (const [key, line] of Object.entries(lines)) {
+                $("#containersList").append(
+                  `<div class="item">
+                    <div class="right floated content">
+                      <div class="ui button" onclick="addContainerItem('${key}');">Add</div>
+                    </div>
+                    <div class="content">
+                      <div class="header">${line.name}</div>
+                      <div class="description">
+                        ${line.ip}:${line.port}
+                      </div>
+                    </div>`
+                );
+              }
+              for (const line of linesAded) {
+                $("#containersAddedList").append(
+                  `<div class="item">
+                    <div class="content">
+                      <div class="header">${line.name}</div>
+                      <div class="description">
+                        ${line.ip}:${line.port}
+                      </div>
+                    </div>`
+                );
+              }
+              linesAded.length &&
+                $("#containersAddedListHeader").removeAttr("hidden");
+              $("#containersList .loader").removeClass("active");
+            } else {
+              parent.msgbox(
+                `Error loading data: ${dockerData.error || hostData.error}`,
+                false
+              );
+            }
+          })
+          .catch((error) => {
+            parent.msgbox("Error loading data: " + error.message, false);
+          });
+      }
+
+      getDockerContainers();
+
+      function addContainerItem(item) {
+        if (lines[item]) {
+          parent.addContainerItem(lines[item]);
+        }
+      }
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
 ## Add a popup window with avaliable docker containers and ability to populate name, ip and port into rules field

https://github.com/tobychui/zoraxy/assets/2050897/9afd8dda-1cee-46e1-8ba8-70d83fae4ee4

### Overview
I use an Rpi4 as a home server, installing each service as a separate Docker container (including Zoraxy). When configuring proxy rules, I need to set the IP and port for each service, requiring me to check the port each time. To simplify the process of adding proxy rules for Docker containers, I've added a simple popup window.

### Requirements
- To get a list of Docker containers, we need to map `/var/run/docker.sock` into the Zoraxy container.
- Because Zoraxy runs in a container, I need to set the host IP (Rpi4) as the target address to make it work. Alternatively, `host.docker.internal` can be used.
browser -> Zoraxy -> Rpi4 -> service

### Flow
When the popup opens:
- Get the current list of proxies.
- Get Docker networks (fetch the `bridge` network to get the host's IP (172.17.0.1)).
- Get the list of containers.
When the `add` button is clicked:
- Close the popup and populate the fields: name = container's name, target = address:port