### PR TITLE
fix: unable to edit proxy if ratelimit is not set or <= 0

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,16 +14,16 @@ COPY ./src/ /opt/zoraxy/source/
 WORKDIR /opt/zoraxy/source/
 
 RUN go mod tidy &&\
-go build -o /usr/local/bin/zoraxy &&\
-rm -r /opt/zoraxy/source/
+    go build -o /usr/local/bin/zoraxy &&\
+    rm -r /opt/zoraxy/source/
 
 FROM docker.io/alpine:3.20
 
 RUN apk add --no-cache bash netcat-openbsd sudo
 
 RUN mkdir -p /opt/zoraxy/source/ &&\
-mkdir -p /opt/zoraxy/config/ &&\
-mkdir -p /usr/local/bin/
+    mkdir -p /opt/zoraxy/config/ &&\
+    mkdir -p /usr/local/bin/
 
 VOLUME [ "/opt/zoraxy/config/" ]
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/golang:alpine
+FROM docker.io/golang:alpine AS build
 
 RUN apk add --no-cache bash netcat-openbsd sudo
 
@@ -8,16 +8,28 @@ RUN mkdir -p /opt/zoraxy/source/ &&\
 
 RUN chmod -R 770 /opt/zoraxy/
 
-VOLUME [ "/opt/zoraxy/config/" ]
-
 # If you build it yourself, you will need to add the src directory into the docker directory.
 COPY ./src/ /opt/zoraxy/source/
 
 WORKDIR /opt/zoraxy/source/
 
 RUN go mod tidy &&\
-    go build -o /usr/local/bin/zoraxy &&\
-    rm -r /opt/zoraxy/source/
+go build -o /usr/local/bin/zoraxy &&\
+rm -r /opt/zoraxy/source/
+
+FROM docker.io/alpine:3.20
+
+RUN apk add --no-cache bash netcat-openbsd sudo
+
+RUN mkdir -p /opt/zoraxy/source/ &&\
+mkdir -p /opt/zoraxy/config/ &&\
+mkdir -p /usr/local/bin/
+
+VOLUME [ "/opt/zoraxy/config/" ]
+
+RUN chmod -R 770 /opt/zoraxy/
+
+COPY --from=build /usr/local/bin/zoraxy /usr/local/bin/zoraxy
 
 RUN chmod 755 /usr/local/bin/zoraxy &&\
     chmod +x /usr/local/bin/zoraxy
@@ -41,4 +53,3 @@ ENV ZTPORT="9993"
 ENTRYPOINT "zoraxy" "-docker=true" "-autorenew=${AUTORENEW}" "-fastgeoip=${FASTGEOIP}" "-log=${LOG}" "-mdns=${MDNS}" "-mdnsname=${MDNSNAME}" "-noauth=${NOAUTH}" "-port=:${PORT}" "-sshlb=${SSHLB}" "-version=${VERSION}" "-webfm=${WEBFM}" "-webroot=${WEBROOT}" "-ztauth=${ZTAUTH}" "-ztport=${ZTPORT}"
 
 HEALTHCHECK --interval=15s --timeout=5s --start-period=10s --retries=3 CMD nc -vz 127.0.0.1 $PORT || exit 1
-

--- a/src/reverseproxy.go
+++ b/src/reverseproxy.go
@@ -475,9 +475,11 @@ func ReverseProxyHandleEditEndpoint(w http.ResponseWriter, r *http.Request) {
 		utils.SendErrorResponse(w, "invalid rate limit number")
 		return
 	}
-	if proxyRateLimit <= 0 {
+	if requireRateLimit && proxyRateLimit <= 0 {
 		utils.SendErrorResponse(w, "rate limit number must be greater than 0")
 		return
+	} else if proxyRateLimit < 0 {
+		proxyRateLimit = 1000
 	}
 
 	// Bypass WebSocket Origin Check


### PR DESCRIPTION
this fix checks the ratelimit value only if the
requireRateLimit is set to true else it will use
the provided ratelimit value unless it is less or equal to 0 then it will default to 1000 (the same value as set inside the ui)

Previous Issue:
![Screenshot from 2024-06-24 22-53-48](https://github.com/tobychui/zoraxy/assets/103888491/5507e8bf-3b36-4362-aa6d-b531792afa86)
