### PR TITLE
Add ZeroTier to Docker container

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 
 A general purpose HTTP reverse proxy and forwarding tool. Now written in Go!
 
-
 ### Features
 
 - Simple to use interface with detail in-system instructions
@@ -38,15 +37,16 @@ A general purpose HTTP reverse proxy and forwarding tool. Now written in Go!
 ## Downloads
 
 [Windows](https://github.com/tobychui/zoraxy/releases/latest/download/zoraxy_windows_amd64.exe)
-/[Linux (amd64)](https://github.com/tobychui/zoraxy/releases/latest/download/zoraxy_linux_amd64)
-/[Linux (arm64)](https://github.com/tobychui/zoraxy/releases/latest/download/zoraxy_linux_arm64)
+/ [Linux (amd64)](https://github.com/tobychui/zoraxy/releases/latest/download/zoraxy_linux_amd64)
+/ [Linux (arm64)](https://github.com/tobychui/zoraxy/releases/latest/download/zoraxy_linux_arm64)
 
-For other systems or architectures, please see [Release](https://github.com/tobychui/zoraxy/releases/latest/) 
+For other systems or architectures, please see [Releases](https://github.com/tobychui/zoraxy/releases/latest/) 
 
 ## Getting Started
+
 [Installing Zoraxy Reverse Proxy: Your Gateway to Efficient Web Routing](https://geekscircuit.com/installing-zoraxy-reverse-proxy-your-gateway-to-efficient-web-routing/)
 
-Thank you for the well written and easy to follow tutorial by Reddit users [itsvmn](https://www.reddit.com/user/itsvmn/)! 
+Thank you for the well written and easy to follow tutorial by Reddit user [itsvmn](https://www.reddit.com/user/itsvmn/)! 
 If you have no background in setting up reverse proxy or web routing, you should check this out before you start setting up your Zoraxy. 
 
 ## Build from Source
@@ -92,7 +92,7 @@ The installation method is same as Linux. For other ARM SBCs, please refer to yo
 
 See the [/docker](https://github.com/tobychui/zoraxy/tree/main/docker) folder for more details.
 
-### Start Paramters
+### Start Parameters
 
 ```
 Usage of zoraxy:
@@ -119,7 +119,7 @@ Usage of zoraxy:
   -webfm
         Enable web file manager for static web server root folder (default true)
   -webroot string
-        Static web server root folder. Only allow chnage in start paramters (default "./www")
+        Static web server root folder. Only allow change in start parameters (default "./www")
   -ztauth string
         ZeroTier authtoken for the local node
   -ztport int

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,10 +1,7 @@
 FROM docker.io/golang:alpine AS build
 
 RUN mkdir -p /opt/zoraxy/source/ &&\
-    mkdir -p /opt/zoraxy/config/ &&\
     mkdir -p /usr/local/bin/
-
-RUN chmod -R 770 /opt/zoraxy/
 
 # If you build it yourself, you will need to add the src directory into the docker directory.
 COPY ./src/ /opt/zoraxy/source/
@@ -13,23 +10,27 @@ WORKDIR /opt/zoraxy/source/
 
 RUN go mod tidy &&\
     go build -o /usr/local/bin/zoraxy &&\
-    rm -r /opt/zoraxy/source/
-
-RUN chmod 755 /usr/local/bin/zoraxy &&\
-    chmod +x /usr/local/bin/zoraxy
+    chmod 755 /usr/local/bin/zoraxy
 
 FROM docker.io/alpine:latest
 
-RUN apk add --no-cache bash netcat-openbsd sudo
+WORKDIR /opt/zoraxy/source/
+
+RUN apk add --no-cache bash netcat-openbsd sudo &&\
+    wget https://dl-cdn.alpinelinux.org/alpine/v3.17/community/x86_64/zerotier-one-1.10.2-r0.apk &&\
+    apk add --no-cache zerotier-one-1.10.2-r0.apk &&\
+    rm -r /opt/zoraxy/source/
 
 COPY --from=build /usr/local/bin/zoraxy /usr/local/bin/zoraxy
-COPY --from=build /opt/zoraxy/config/ /opt/zoraxy/config
-
-VOLUME [ "/opt/zoraxy/config/" ]
+COPY --chmod=700 ./entrypoint.sh /opt/zoraxy/
 
 WORKDIR /opt/zoraxy/config/
 
+ENV ZEROTIER="false"
+
 ENV AUTORENEW="86400"
+ENV CFGUPGRADE="true"
+ENV DOCKER="true"
 ENV EARLYRENEW="30"
 ENV FASTGEOIP="false"
 ENV MDNS="true"
@@ -40,9 +41,12 @@ ENV SSHLB="false"
 ENV VERSION="false"
 ENV WEBFM="true"
 ENV WEBROOT="./www"
-ENV ZTAUTH="''"
+ENV ZTAUTH=""
 ENV ZTPORT="9993"
 
-ENTRYPOINT "zoraxy" "-docker=true" "-autorenew=${AUTORENEW}" "-earlyrenew=${EARLYRENEW}" "-fastgeoip=${FASTGEOIP}" "-mdns=${MDNS}" "-mdnsname=${MDNSNAME}" "-noauth=${NOAUTH}" "-port=:${PORT}" "-sshlb=${SSHLB}" "-version=${VERSION}" "-webfm=${WEBFM}" "-webroot=${WEBROOT}" "-ztauth=${ZTAUTH}" "-ztport=${ZTPORT}"
+VOLUME [ "/opt/zoraxy/config/", "/var/lib/zerotier-one/" ]
+
+ENTRYPOINT [ "/opt/zoraxy/entrypoint.sh" ]
 
 HEALTHCHECK --interval=15s --timeout=5s --start-period=10s --retries=3 CMD nc -vz 127.0.0.1 $PORT || exit 1
+

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,73 +1,98 @@
-# [zoraxy](https://github.com/tobychui/zoraxy/) </br>
+# Zoraxy Docker
 
 [![Repo](https://img.shields.io/badge/Docker-Repo-007EC6?labelColor-555555&color-007EC6&logo=docker&logoColor=fff&style=flat-square)](https://hub.docker.com/r/zoraxydocker/zoraxy)
 [![Version](https://img.shields.io/docker/v/zoraxydocker/zoraxy/latest?labelColor-555555&color-007EC6&style=flat-square)](https://hub.docker.com/r/zoraxydocker/zoraxy)
 [![Size](https://img.shields.io/docker/image-size/zoraxydocker/zoraxy/latest?sort=semver&labelColor-555555&color-007EC6&style=flat-square)](https://hub.docker.com/r/zoraxydocker/zoraxy)
 [![Pulls](https://img.shields.io/docker/pulls/zoraxydocker/zoraxy?labelColor-555555&color-007EC6&style=flat-square)](https://hub.docker.com/r/zoraxydocker/zoraxy)
 
-## Setup: </br>
-Although not required, it is recommended to give Zoraxy a dedicated location on the host to mount the container. That way, the host/user can access them whenever needed. A volume will be created automatically within Docker if a location is not specified. </br>
+## Usage
 
-You may also need to portforward your 80/443 to allow http and https traffic. If you are accessing the interface from outside of the local network, you may also need to forward your management port. If you know how to do this, great! If not, find the manufacturer of your router and search on how to do that. There are too many to be listed here. </br>
+If you are attempting to access your service from outside your network, make sure to forward ports 80 and 443 to the Zoraxy host to allow web traffic. If you know how to do this, great! If not, find the manufacturer of your router and search on how to do that. There are too many to be listed here. Read more about it from [whatismyip](https://www.whatismyip.com/port-forwarding/).
 
-The examples below are not exactly how it should be set up, rather they give a general idea of usage.
+In the examples below, make sure to update `/path/to/zoraxy/config/` with your actual path. If a path is not provided, a Docker volume will be created at the location but it is recommended to store the data at a defined host location.
 
-### Using Docker run </br>
+Once setup, access the webui at `http://<host-ip>:8000` to configure Zoraxy. Change the port in the URL if you changed the management port.
+
+### Docker Run
+
 ```
-docker run -d --name (container name) -p 80:80 -p 443:443 -p (management external):(management internal) -v (path to storage directory):/opt/zoraxy/data/ -e (flag)="(value)" zoraxydocker/zoraxy:latest
+docker run -d \
+  --name zoraxy \
+  --restart unless-stopped \
+  -p 80:80 \
+  -p 443:443 \
+  -p 8000:8000 \
+  -v /path/to/zoraxy/config/:/opt/zoraxy/config/ \
+  -v /path/to/zerotier/config/:/var/lib/zerotier-one/ \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -v /etc/localtime:/etc/localtime \
+  -e FASTGEOIP="true" \
+  -e ZEROTIER="true" \
+  zoraxydocker/zoraxy:latest
 ```
 
-### Using Docker Compose </br>
+### Docker Compose
+
 ```yml
 services:
-  zoraxy-docker:
-    image: zoraxydocker/zoraxy:latest
-    container_name: (container name)
-    ports:
-      - 80:80
-      - 443:443
-      - (management external):(management internal)
-    volumes:
-      - (path to storage directory):/opt/zoraxy/config/
-    environment:
-      (flag): "(value)"
-```
-
-| Operator | Need | Details |
-|:-|:-|:-|
-| `-d` | Yes | will run the container in the background. |
-| `--name (container name)` | No | Sets the name of the container to the following word. You can change this to whatever you want. |
-| `-p (ports)` | Yes | Depending on how your network is setup, you may need to portforward 80, 443, and the management port. |
-| `-v (path to storage directory):/opt/zoraxy/config/` | Recommend | Sets the folder that holds your files. This should be the place you just chose. By default, it will create a Docker volume for the files for persistency but they will not be accessible. |
-| `-v /var/run/docker.sock:/var/run/docker.sock` | No | Used for autodiscovery. |
-| `-v /etc/localtime:/etc/localtime` | No | Uses the hosts time in the container. |
-| `-e (flag)="(value)"` | No | Arguments to run Zoraxy with. They are simply just capitalized Zoraxy flags. `-docker=true` is always set by default. See examples below. |
-| `zoraxydocker/zoraxy:latest` | Yes | The repository on Docker hub. By default, it is the latest version that is published. |
-
-> [!IMPORTANT]
-> Docker usage of the port flag should not include the colon. Ex: `-e PORT="8000"` for Docker run and `PORT: "8000"` for Docker compose.
-
-## Examples: </br>
-### Docker Run </br>
-```
-docker run -d --name zoraxy -p 80:80 -p 443:443 -p 8005:8005 -v /home/docker/Containers/Zoraxy:/opt/zoraxy/config/ -v /var/run/docker.sock:/var/run/docker.sock -v /etc/localtime:/etc/localtime -e PORT="8005" -e FASTGEOIP="true" zoraxydocker/zoraxy:latest
-```
-
-### Docker Compose </br>
-```yml
-services:
-  zoraxy-docker:
+  zoraxy:
     image: zoraxydocker/zoraxy:latest
     container_name: zoraxy
+    restart: unless-stopped
     ports:
       - 80:80
       - 443:443
-      - 8005:8005
+      - 8000:8000
     volumes:
-      - /home/docker/Containers/Zoraxy:/opt/zoraxy/config/
+      - /path/to/zoraxy/config/:/opt/zoraxy/config/
+      - /path/to/zerotier/config/:/var/lib/zerotier-one/
       - /var/run/docker.sock:/var/run/docker.sock
       - /etc/localtime:/etc/localtime
     environment:
-      PORT: "8005"
       FASTGEOIP: "true"
+      ZEROTIER: "true"
 ```
+
+### Ports
+
+| Port | Details |
+|:-|:-|
+| `80` | HTTP traffic. |
+| `443` | HTTPS traffic. |
+| `8000` | Management interface. Can be changed with the `PORT` env. |
+
+### Volumes
+
+| Volume | Details |
+|:-|:-|
+| `/opt/zoraxy/config/` | Zoraxy configuration. |
+| `/var/lib/zerotier-one/` | ZeroTier configuration. Only required if you wish to use ZeroTier. |
+| `/var/run/docker.sock` | Docker socket. Used for additional functionality with Zoraxy. |
+| `/etc/localtime` | Localtime. Set to ensure the host and container are synchronized. |
+
+### Environment
+
+Variables are the same as those in [Start Parameters](https://github.com/tobychui/zoraxy?tab=readme-ov-file#start-paramters).
+
+| Variable | Default | Details |
+|:-|:-|:-|
+| `AUTORENEW` | `86400` (Integer) | ACME auto TLS/SSL certificate renew check interval. |
+| `CFGUPGRADE` | `true` (Boolean) | Enable auto config upgrade if breaking change is detected. |
+| `DOCKER` | `true` (Boolean) | Run Zoraxy in docker compatibility mode. |
+| `EARLYRENEW` | `30` (Integer) | Number of days to early renew a soon expiring certificate. |
+| `FASTGEOIP` | `false`  (Boolean) | Enable high speed geoip lookup, require 1GB extra memory (Not recommend for low end devices). |
+| `MDNS` | `true` (Boolean) | Enable mDNS scanner and transponder. |
+| `MDNSNAME` | `''` (String) | mDNS name, leave empty to use default (zoraxy_{node-uuid}.local). |
+| `NOAUTH` | `false` (Boolean) | Disable authentication for management interface. |
+| `PORT` | `8000` (Integer) | Management web interface listening port |
+| `SSHLB` | `false` (Boolean) | Allow loopback web ssh connection (DANGER). |
+| `VERSION` | `false` (Boolean) | Show version of this server. |
+| `WEBFM` | `true` (Boolean) | Enable web file manager for static web server root folder. |
+| `WEBROOT` | `./www` (String) | Static web server root folder. Only allow change in start parameters. |
+| `ZEROTIER` | `false` (Boolean) | Enable ZeroTier functionality for GAN. |
+| `ZTAUTH` | `""` (String) | ZeroTier authtoken for the local node. |
+| `ZTPORT` | `9993` (Integer) | ZeroTier controller API port. |
+
+> [!IMPORTANT]
+> Contrary to the Zoraxy README, Docker usage of the port flag should NOT include the colon. Ex: `-e PORT="8000"` for Docker run and `PORT: "8000"` for Docker compose.
+

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+if [ "$ZEROTIER" = "true" ]; then
+  echo "Starting ZeroTier daemon..."
+  zerotier-one -d
+fi
+
+echo "Starting Zoraxy..."
+exec zoraxy \
+  -autorenew="$AUTORENEW" \
+  -cfgupgrade="$CFGUPGRADE" \
+  -docker="$DOCKER" \
+  -earlyrenew="$EARLYRENEW" \
+  -fastgeoip="$FASTGEOIP" \
+  -mdns="$MDNS" \
+  -mdnsname="$MDNSNAME" \
+  -noauth="$NOAUTH" \
+  -port=:"$PORT" \
+  -sshlb="$SSHLB" \
+  -version="$VERSION" \
+  -webfm="$WEBFM" \
+  -webroot="$WEBROOT" \
+  -ztauth="$ZTAUTH" \
+  -ztport="$ZTPORT"
+


### PR DESCRIPTION
When the env variable `ZTAUTH` is set, ZeroTier is started in daemon mode, otherwise it is not run at all. With ZeroTier running, Zoraxy seems to get the GAN network controller ID and I can create a network.