### PR TITLE
Make redirection URL links absolute links

### DIFF
--- a/src/web/components/redirection.html
+++ b/src/web/components/redirection.html
@@ -164,7 +164,7 @@
         $.get("/api/redirect/list", function(data){
             data.forEach(function(entry){
                 $("#redirectionRuleList").append(`<tr>
-                    <td><a href="${entry.RedirectURL}" target="_blank">${entry.RedirectURL}</a></td>
+                    <td><a href="//${entry.RedirectURL}" target="_blank">${entry.RedirectURL}</a></td>
                     <td>${entry.TargetURL}</td>
                     <td>${entry.ForwardChildpath?"<i class='ui green checkmark icon'></i>":"<i class='ui red remove icon'></i>"}</td>
                     <td>${entry.StatusCode==307?"Temporary Redirect (307)":"Moved Permanently (301)"}</td>


### PR DESCRIPTION
This changes the redirection URL links from relative links (ex: `zoraxy.mysite.net/my-redirect.mysite.net`) to absolute links (ex: `my-redirect.mysite.net`).

I think this was the intent for the redirection page. If not, please ignore.

PS - thanks for a great piece of software.