### PR TITLE
Symlink ZeroTier var to Zoraxy config

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -58,7 +58,7 @@ ENV WEBROOT="./www"
 ENV ZTAUTH=""
 ENV ZTPORT="9993"
 
-VOLUME [ "/opt/zoraxy/config/", "/var/lib/zerotier-one/" ]
+VOLUME [ "/opt/zoraxy/config/" ]
 
 ENTRYPOINT [ "/opt/zoraxy/entrypoint.sh" ]
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -4,6 +4,10 @@ update-ca-certificates
 echo "CA certificates updated"
 
 if [ "$ZEROTIER" = "true" ]; then
+  if [ ! -d "/opt/zoraxy/config/zerotier/" ]; then
+    mkdir -p /opt/zoraxy/config/zerotier/
+  fi
+  ln -s /opt/zoraxy/config/zerotier/ /var/lib/zerotier-one
   zerotier-one -d
   echo "ZeroTier daemon started"
 fi


### PR DESCRIPTION
https://github.com/tobychui/zoraxy/issues/388

Instead of creating a separate volume for ZeroTier itself, we can symlink its var directory to the Zoraxy config and make use of its volume.

This won't cause a loss of data as any users who mount a directory at `/var/lib/zerotier-one` won't have the symlink. If any user wants to simply their volumes, just move any data from the old ZeroTier mount to `zerotier/` in the Zoraxy config directory.