### PR TITLE
[WIP] Add Authentik forward auth support

### DIFF
--- a/src/api.go
+++ b/src/api.go
@@ -81,6 +81,7 @@ func RegisterTLSAPIs(authRouter *auth.RouterDef) {
 // Register the APIs for Authentication handlers like Authelia and OAUTH2
 func RegisterAuthenticationHandlerAPIs(authRouter *auth.RouterDef) {
 	authRouter.HandleFunc("/api/sso/Authelia", autheliaRouter.HandleSetAutheliaURLAndHTTPS)
+	authRouter.HandleFunc("/api/sso/Authentik", authentikRouter.HandleSetAuthentikURLAndHTTPS)
 }
 
 // Register the APIs for redirection rules management functions

--- a/src/def.go
+++ b/src/def.go
@@ -10,6 +10,7 @@ package main
 import (
 	"embed"
 	"flag"
+	"imuslab.com/zoraxy/mod/auth/sso/authentik"
 	"net/http"
 	"time"
 
@@ -141,7 +142,8 @@ var (
 	loadBalancer       *loadbalance.RouteManager //Global scope loadbalancer, store the state of the lb routing
 
 	//Authentication Provider
-	autheliaRouter *authelia.AutheliaRouter //Authelia router for Authelia authentication
+	autheliaRouter  *authelia.AutheliaRouter   //Authelia router for Authelia authentication
+	authentikRouter *authentik.AuthentikRouter //Authentik router for Authentik authentication
 
 	//Helper modules
 	EmailSender       *email.Sender         //Email sender that handle email sending

--- a/src/mod/auth/sso/authentik/authentik.go
+++ b/src/mod/auth/sso/authentik/authentik.go
@@ -106,7 +106,7 @@ func (ar *AuthentikRouter) HandleAuthentikAuth(w http.ResponseWriter, r *http.Re
 	reqUrl := scheme + "://" + r.Host + r.RequestURI
 	// Pass request to outpost if path matches outpost prefix
 	if reqPath := strings.TrimPrefix(r.URL.Path, "/"); strings.HasPrefix(reqPath, outpostPrefix) {
-		req, err := http.NewRequest(r.Method, authentikBaseURL+r.URL.Path, nil)
+		req, err := http.NewRequest(r.Method, authentikBaseURL+r.RequestURI, r.Body)
 		if err != nil {
 			ar.options.Logger.PrintAndLog("Authentik", "Unable to create request", err)
 			w.WriteHeader(401)
@@ -144,7 +144,7 @@ func (ar *AuthentikRouter) HandleAuthentikAuth(w http.ResponseWriter, r *http.Re
 		return errors.New("unauthorized")
 	}
 
-	req.Header.Add("X-Original-URL", reqUrl)
+	req.Header.Set("X-Original-URL", reqUrl)
 
 	// Copy cookies from the incoming request
 	for _, cookie := range r.Cookies() {

--- a/src/mod/auth/sso/authentik/authentik.go
+++ b/src/mod/auth/sso/authentik/authentik.go
@@ -1,0 +1,169 @@
+package authentik
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"imuslab.com/zoraxy/mod/database"
+	"imuslab.com/zoraxy/mod/info/logger"
+	"imuslab.com/zoraxy/mod/utils"
+)
+
+type AuthentikRouterOptions struct {
+	UseHTTPS     bool   //If the Authentik server is using HTTPS
+	AuthentikURL string //The URL of the Authentik server
+	Logger       *logger.Logger
+	Database     *database.Database
+}
+
+type AuthentikRouter struct {
+	options *AuthentikRouterOptions
+}
+
+// NewAuthentikRouter creates a new AuthentikRouter object
+func NewAuthentikRouter(options *AuthentikRouterOptions) *AuthentikRouter {
+	options.Database.NewTable("authentik")
+
+	//Read settings from database, if exists
+	options.Database.Read("authentik", "authentikURL", &options.AuthentikURL)
+	options.Database.Read("authentik", "useHTTPS", &options.UseHTTPS)
+
+	return &AuthentikRouter{
+		options: options,
+	}
+}
+
+// HandleSetAuthentikURLAndHTTPS is the internal handler for setting the Authentik URL and HTTPS
+func (ar *AuthentikRouter) HandleSetAuthentikURLAndHTTPS(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodGet {
+		//Return the current settings
+		js, _ := json.Marshal(map[string]interface{}{
+			"useHTTPS":     ar.options.UseHTTPS,
+			"authentikURL": ar.options.AuthentikURL,
+		})
+
+		utils.SendJSONResponse(w, string(js))
+		return
+	} else if r.Method == http.MethodPost {
+		//Update the settings
+		AuthentikURL, err := utils.PostPara(r, "authentikURL")
+		if err != nil {
+			utils.SendErrorResponse(w, "authentikURL not found")
+			return
+		}
+
+		useHTTPS, err := utils.PostBool(r, "useHTTPS")
+		if err != nil {
+			useHTTPS = false
+		}
+
+		//Write changes to runtime
+		ar.options.AuthentikURL = AuthentikURL
+		ar.options.UseHTTPS = useHTTPS
+
+		//Write changes to database
+		ar.options.Database.Write("authentik", "authentikURL", AuthentikURL)
+		ar.options.Database.Write("authentik", "useHTTPS", useHTTPS)
+
+		utils.SendOK(w)
+	} else {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+}
+
+// HandleAuthentikAuth is the internal handler for Authentik authentication
+// Set useHTTPS to true if your Authentik server is using HTTPS
+// Set AuthentikURL to the URL of the Authentik server, e.g. Authentik.example.com
+func (ar *AuthentikRouter) HandleAuthentikAuth(w http.ResponseWriter, r *http.Request) error {
+	const outpostPrefix = "outpost.goauthentik.io"
+	client := &http.Client{}
+
+	if ar.options.AuthentikURL == "" {
+		ar.options.Logger.PrintAndLog("Authentik", "Authentik URL not set", nil)
+		w.WriteHeader(500)
+		w.Write([]byte("500 - Internal Server Error"))
+		return errors.New("authentik URL not set")
+	}
+	protocol := "http"
+	if ar.options.UseHTTPS {
+		protocol = "https"
+	}
+
+	authentikBaseURL := protocol + "://" + ar.options.AuthentikURL
+	//Remove tailing slash if any
+	authentikBaseURL = strings.TrimSuffix(authentikBaseURL, "/")
+
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+	reqUrl := scheme + "://" + r.Host + r.RequestURI
+	// Pass request to outpost if path matches outpost prefix
+	if reqPath := strings.TrimPrefix(r.URL.Path, "/"); strings.HasPrefix(reqPath, outpostPrefix) {
+		req, err := http.NewRequest(r.Method, authentikBaseURL+r.URL.Path, nil)
+		if err != nil {
+			ar.options.Logger.PrintAndLog("Authentik", "Unable to create request", err)
+			w.WriteHeader(401)
+			return errors.New("unauthorized")
+		}
+		req.Header.Set("X-Original-URL", reqUrl)
+		req.Header.Set("Host", r.Host)
+		for _, cookie := range r.Cookies() {
+			req.AddCookie(cookie)
+		}
+		if resp, err := client.Do(req); err != nil {
+			ar.options.Logger.PrintAndLog("Authentik", "Unable to pass request to Authentik outpost", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return errors.New("internal server error")
+		} else {
+			defer resp.Body.Close()
+			for k := range resp.Header {
+				w.Header().Set(k, resp.Header.Get(k))
+			}
+			w.WriteHeader(resp.StatusCode)
+			if _, err = io.Copy(w, resp.Body); err != nil {
+				ar.options.Logger.PrintAndLog("Authentik", "Unable to pass Authentik outpost response to client", err)
+				w.WriteHeader(http.StatusInternalServerError)
+				return errors.New("internal server error")
+			}
+		}
+		return nil
+	}
+
+	//Make a request to Authentik to verify the request
+	req, err := http.NewRequest(http.MethodGet, authentikBaseURL+"/"+outpostPrefix+"/auth/nginx", nil)
+	if err != nil {
+		ar.options.Logger.PrintAndLog("Authentik", "Unable to create request", err)
+		w.WriteHeader(401)
+		return errors.New("unauthorized")
+	}
+
+	req.Header.Add("X-Original-URL", reqUrl)
+
+	// Copy cookies from the incoming request
+	for _, cookie := range r.Cookies() {
+		req.AddCookie(cookie)
+	}
+
+	// Making the verification request
+	resp, err := client.Do(req)
+	if err != nil {
+		ar.options.Logger.PrintAndLog("Authentik", "Unable to verify", err)
+		w.WriteHeader(401)
+		return errors.New("unauthorized")
+	}
+
+	if resp.StatusCode != 200 {
+		redirectURL := authentikBaseURL + "/" + outpostPrefix + "/start?rd=" + url.QueryEscape(scheme+"://"+r.Host+r.URL.String())
+		http.Redirect(w, r, redirectURL, http.StatusSeeOther)
+		return errors.New("unauthorized")
+	}
+
+	return nil
+}

--- a/src/mod/dynamicproxy/authProviders.go
+++ b/src/mod/dynamicproxy/authProviders.go
@@ -43,6 +43,12 @@ func handleAuthProviderRouting(sep *ProxyEndpoint, w http.ResponseWriter, r *htt
 			h.Parent.Option.Logger.LogHTTPRequest(r, "host", 401)
 			return true
 		}
+	} else if sep.AuthenticationProvider.AuthMethod == AuthMethodAuthentik {
+		err := h.handleAuthentikAuth(w, r)
+		if err != nil {
+			h.Parent.Option.Logger.LogHTTPRequest(r, "host", 401)
+			return true
+		}
 	}
 
 	//No authentication provider, do not need to handle
@@ -105,4 +111,8 @@ func handleBasicAuth(w http.ResponseWriter, r *http.Request, pe *ProxyEndpoint) 
 // Handle authelia auth routing
 func (h *ProxyHandler) handleAutheliaAuth(w http.ResponseWriter, r *http.Request) error {
 	return h.Parent.Option.AutheliaRouter.HandleAutheliaAuth(w, r)
+}
+
+func (h *ProxyHandler) handleAuthentikAuth(w http.ResponseWriter, r *http.Request) error {
+	return h.Parent.Option.AuthentikRouter.HandleAuthentikAuth(w, r)
 }

--- a/src/mod/dynamicproxy/typedef.go
+++ b/src/mod/dynamicproxy/typedef.go
@@ -9,6 +9,7 @@ package dynamicproxy
 */
 import (
 	_ "embed"
+	"imuslab.com/zoraxy/mod/auth/sso/authentik"
 	"net"
 	"net/http"
 	"sync"
@@ -61,7 +62,8 @@ type RouterOption struct {
 	LoadBalancer       *loadbalance.RouteManager //Load balancer that handle load balancing of proxy target
 
 	/* Authentication Providers */
-	AutheliaRouter *authelia.AutheliaRouter //Authelia router for Authelia authentication
+	AutheliaRouter  *authelia.AutheliaRouter   //Authelia router for Authelia authentication
+	AuthentikRouter *authentik.AuthentikRouter //Authentik router for Authentik authentication
 
 	/* Utilities */
 	Logger *logger.Logger //Logger for reverse proxy requets
@@ -141,6 +143,7 @@ const (
 	AuthMethodBasic                      //Basic Auth
 	AuthMethodAuthelia                   //Authelia
 	AuthMethodOauth2                     //Oauth2
+	AuthMethodAuthentik
 )
 
 type AuthenticationProvider struct {

--- a/src/reverseproxy.go
+++ b/src/reverseproxy.go
@@ -115,6 +115,7 @@ func ReverseProxtInit() {
 		WebDirectory:       *path_webserver,
 		AccessController:   accessController,
 		AutheliaRouter:     autheliaRouter,
+		AuthentikRouter:    authentikRouter,
 		LoadBalancer:       loadBalancer,
 		Logger:             SystemWideLogger,
 	})
@@ -578,6 +579,8 @@ func ReverseProxyHandleEditEndpoint(w http.ResponseWriter, r *http.Request) {
 		newProxyEndpoint.AuthenticationProvider.AuthMethod = dynamicproxy.AuthMethodAuthelia
 	} else if authProviderType == 3 {
 		newProxyEndpoint.AuthenticationProvider.AuthMethod = dynamicproxy.AuthMethodOauth2
+	} else if authProviderType == 4 {
+		newProxyEndpoint.AuthenticationProvider.AuthMethod = dynamicproxy.AuthMethodAuthentik
 	} else {
 		newProxyEndpoint.AuthenticationProvider.AuthMethod = dynamicproxy.AuthMethodNone
 	}

--- a/src/start.go
+++ b/src/start.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"imuslab.com/zoraxy/mod/auth/sso/authentik"
 	"log"
 	"net/http"
 	"os"
@@ -144,6 +145,13 @@ func startupSequence() {
 		AutheliaURL: "",    // Automatic populate in router initiation
 		Logger:      SystemWideLogger,
 		Database:    sysdb,
+	})
+
+	authentikRouter = authentik.NewAuthentikRouter(&authentik.AuthentikRouterOptions{
+		UseHTTPS:     false, // Automatic populate in router initiation
+		AuthentikURL: "",    // Automatic populate in router initiation
+		Logger:       SystemWideLogger,
+		Database:     sysdb,
 	})
 
 	//Create a statistic collector

--- a/src/web/components/httprp.html
+++ b/src/web/components/httprp.html
@@ -174,6 +174,7 @@
                             ${subd.AuthenticationProvider.AuthMethod == 0x1?`<i class="ui grey key icon"></i> Basic Auth`:``}
                             ${subd.AuthenticationProvider.AuthMethod == 0x2?`<i class="ui blue key icon"></i> Authelia`:``}
                             ${subd.AuthenticationProvider.AuthMethod == 0x3?`<i class="ui yellow key icon"></i> Oauth2`:``}
+                            ${subd.AuthenticationProvider.AuthMethod == 0x4?`<i class="ui blue key icon"></i> Authentik`:``}
                             ${subd.AuthenticationProvider.AuthMethod != 0x0 && subd.RequireRateLimit?"<br>":""}
                             ${subd.RequireRateLimit?`<i class="ui green check icon"></i> Rate Limit @ ${subd.RateLimit} req/s`:``}
                             ${subd.AuthenticationProvider.AuthMethod == 0x0 && !subd.RequireRateLimit?`<small style="opacity: 0.3; pointer-events: none; user-select: none;">No Special Settings</small>`:""}
@@ -380,6 +381,12 @@
                             <div class="ui radio checkbox">
                                 <input type="radio" value="2" name="authProviderType" ${authProvider==0x2?"checked":""}>
                                 <label>Authelia</label>
+                            </div>
+                        </div>
+                        <div class="field">
+                            <div class="ui radio checkbox">
+                                <input type="radio" value="4" name="authProviderType" ${authProvider==0x4?"checked":""}>
+                                <label>Authentik</label>
                             </div>
                         </div>
                     </div>

--- a/src/web/components/sso.html
+++ b/src/web/components/sso.html
@@ -34,6 +34,27 @@
         </form>
     </div>
     <div class="ui divider"></div>
+    <div class="ui basic segment">
+        <h3>Authentik</h3>
+        <p>Configuration settings for Authentik authentication provider.</p>
+
+        <form class="ui form">
+            <div class="field">
+                <label for="authentikServerUrl">Authentik Server URL</label>
+                <input type="text" id="authentikServerUrl" name="authentikServerUrl" placeholder="Enter Authentik Server URL">
+                <small>Example: auth.example.com</small>
+            </div>
+            <div class="field">
+                <div class="ui checkbox">
+                    <input type="checkbox" id="authentikUseHttps" name="useHttps">
+                    <label for="authentikUseHttps">Use HTTPS</label>
+                    <small>Check this if your Authentik server uses HTTPS</small>
+                </div>
+            </div>
+            <button class="ui basic button" onclick="event.preventDefault(); updateAuthentikSettings();"><i class="green check icon"></i> Apply Change</button>
+        </form>
+    </div>
+    <div class="ui divider"></div>
 </div>
 
 <script>
@@ -45,6 +66,18 @@
             success: function(data) {
                 $('#autheliaServerUrl').val(data.autheliaURL);
                 $('#useHttps').prop('checked', data.useHTTPS);
+            },
+            error: function(jqXHR, textStatus, errorThrown) {
+                console.error('Error fetching SSO settings:', textStatus, errorThrown);
+            }
+        });
+        $.cjax({
+            url: '/api/sso/Authentik',
+            method: 'GET',
+            dataType: 'json',
+            success: function(data) {
+                $('#authentikServerUrl').val(data.authentikURL);
+                $('#authentikUseHttps').prop('checked', data.useHTTPS);
             },
             error: function(jqXHR, textStatus, errorThrown) {
                 console.error('Error fetching SSO settings:', textStatus, errorThrown);
@@ -73,6 +106,30 @@
             },
             error: function(jqXHR, textStatus, errorThrown) {
                 console.error('Error updating Authelia settings:', textStatus, errorThrown);
+            }
+        });
+    }
+    function updateAuthentikSettings(){
+        var authentikServerUrl = $('#authentikServerUrl').val();
+        var useHttps = $('#authentikUseHttps').prop('checked');
+
+        $.cjax({
+            url: '/api/sso/Authentik',
+            method: 'POST',
+            data: {
+                authentikURL: authentikServerUrl,
+                useHTTPS: useHttps
+            },
+            success: function(data) {
+                if (data.error != undefined) {
+                    $.msgbox(data.error, false);
+                    return;
+                }
+                msgbox('Authentik settings updated', true);
+                console.log('Authentik settings updated:', data);
+            },
+            error: function(jqXHR, textStatus, errorThrown) {
+                console.error('Error updating Authentik settings:', textStatus, errorThrown);
             }
         });
     }


### PR DESCRIPTION
Added basic forward auth support for Authentik. This PR is a draft, it has some known issues and needs further development and (probably) upstream help from Authentik:

- It only works with the embedded outpost (the built-in one) of Authentik. You need to edit the embedded outpost and add a Proxy provider to it.
- It does not work with external deployed Proxy outpost, you'll get a 400 error after authenticated. I suspect I'm hitting https://github.com/goauthentik/authentik/issues/10848. Help wanted on this part.
- Probably need to migrate database schema? I have no idea.

To configure: fill server address (host / domainname, and port) in SSO page, and check "HTTPS" if applicable. Then edit any reverse proxy, select "Authentik" in Authentication Provider section, and save.

**Notice**: please backup your database and configuration files before testing branches.