### PR TITLE
Add FreeBSD amd64 support

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,5 +1,5 @@
 # PLATFORMS := darwin/amd64 darwin/arm64 freebsd/amd64 linux/386 linux/amd64 linux/arm linux/arm64 linux/mipsle windows/386 windows/amd64 windows/arm windows/arm64
-PLATFORMS := linux/amd64 linux/386 linux/arm linux/arm64 linux/mipsle linux/riscv64 windows/amd64
+PLATFORMS := linux/amd64 linux/386 linux/arm linux/arm64 linux/mipsle linux/riscv64 windows/amd64 freebsd/amd64
 temp = $(subst /, ,$@)
 os = $(word 1, $(temp))
 arch = $(word 2, $(temp))

--- a/src/mod/sshprox/embed.go
+++ b/src/mod/sshprox/embed.go
@@ -1,12 +1,12 @@
-//go:build (windows && amd64) || (linux && mipsle) || (linux && riscv64)
-// +build windows,amd64 linux,mipsle linux,riscv64
+//go:build (windows && amd64) || (linux && mipsle) || (linux && riscv64) || (freebsd && amd64)
+// +build windows,amd64 linux,mipsle linux,riscv64 freebsd,amd64
 
 package sshprox
 
 import "embed"
 
 /*
-	Bianry embedding
+	Binary embedding
 
 	Make sure when compile, gotty binary exists in static.gotty
 */


### PR DESCRIPTION
Adds FreeBSD build target.
No SSH-Web terminal (gotty) support, since it exits with a `fatal error: runtime: address space conflict` on my machine.

Closes #625