### PR TITLE
fix(authelia): original headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,9 +199,9 @@ Loopback web SSH connections, by default, are disabled. This means that if you a
 
 Some section of Zoraxy are contributed by our amazing community and if you have any issues regarding those sections, it would be more efficient if you can tag them directly when creating an issue report.
 
-Authelia Support added by @7brend7
-Authentik Support added by @JokerQyou
-Docker Container List by @eyerrock
+- Authelia Support added by [@7brend7](https://github.com/7brend7)
+- Authentik Support added by [@JokerQyou](https://github.com/JokerQyou)
+- Docker Container List by [@eyerrock](https://github.com/eyerrock)
 
 Thank you so much for your contributions!
 

--- a/README.md
+++ b/README.md
@@ -195,6 +195,16 @@ Loopback web SSH connections, by default, are disabled. This means that if you a
 ./zoraxy -sshlb=true
 ```
 
+## Community Maintained Sections
+
+Some section of Zoraxy are contributed by our amazing community and if you have any issues regarding those sections, it would be more efficient if you can tag them directly when creating an issue report.
+
+Authelia Support added by @7brend7
+Authentik Support added by @JokerQyou
+Docker Container List by @eyerrock
+
+Thank you so much for your contributions!
+
 ## Sponsor This Project
 
 If you like the project and want to support us, please consider a donation. You can use the links below


### PR DESCRIPTION
This fixes the original headers imparted to Authelia, including adding the X-Forwarded-For header, X-Fowarded-Method, and fixing the URI which was absent from the X-Original-URL header. This is also solved by #640 but this change is not as drastic and is not breaking.

Fixes #502, Fixes #577
