### PR TITLE
refactor: docker container list

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -72,6 +72,8 @@ ENV WEBROOT="./www"
 
 VOLUME [ "/opt/zoraxy/config/" ]
 
+LABEL com.imuslab.zoraxy.container-identifier="Zoraxy"
+
 ENTRYPOINT [ "/opt/zoraxy/entrypoint.sh" ]
 
 HEALTHCHECK --interval=15s --timeout=5s --start-period=10s --retries=3 CMD nc -vz 127.0.0.1 $PORT || exit 1

--- a/docker/README.md
+++ b/docker/README.md
@@ -19,6 +19,7 @@ Once setup, access the webui at `http://<host-ip>:8000` to configure Zoraxy. Cha
 docker run -d \
   --name zoraxy \
   --restart unless-stopped \
+  --add-host=host.docker.internal:host-gateway \
   -p 80:80 \
   -p 443:443 \
   -p 8000:8000 \
@@ -47,6 +48,8 @@ services:
       - /path/to/zoraxy/plugin/:/opt/zoraxy/plugin/
       - /var/run/docker.sock:/var/run/docker.sock
       - /etc/localtime:/etc/localtime
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       FASTGEOIP: "true"
 ```
@@ -67,6 +70,11 @@ services:
 | `/opt/zoraxy/plugin/` | Zoraxy plugins. |
 | `/var/run/docker.sock` | Docker socket. Used for additional functionality with Zoraxy. |
 | `/etc/localtime` | Localtime. Set to ensure the host and container are synchronized. |
+
+### Extra Hosts
+| Host | Details |
+|:-|:-|
+| `host.docker.internal:host-gateway` | Resolves host.docker.internal to the host’s gateway IP on the Docker bridge network, allowing containers to access services running on the host machine. |
 
 ### Environment
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -12,5 +12,7 @@ services:
       - /path/to/zoraxy/plugin/:/opt/zoraxy/plugin/
       - /var/run/docker.sock:/var/run/docker.sock
       - /etc/localtime:/etc/localtime
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       FASTGEOIP: "true"

--- a/src/mod/dockerux/docker.go
+++ b/src/mod/dockerux/docker.go
@@ -20,7 +20,7 @@ func (d *UXOptimizer) HandleDockerAvailable(w http.ResponseWriter, r *http.Reque
 }
 
 func (d *UXOptimizer) HandleDockerContainersList(w http.ResponseWriter, r *http.Request) {
-	apiClient, err := client.NewClientWithOpts(client.WithVersion("1.43"))
+	apiClient, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
 		d.SystemWideLogger.PrintAndLog("Docker", "Unable to create new docker client", err)
 		utils.SendErrorResponse(w, "Docker client initiation failed")

--- a/src/web/snippet/dockerContainersList.html
+++ b/src/web/snippet/dockerContainersList.html
@@ -1,14 +1,14 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <!-- Notes: This should be open in its original path-->
+    <!-- Notes: This should be open in its original path -->
     <meta charset="utf-8" />
     <link rel="stylesheet" href="../script/semantic/semantic.min.css" />
     <script src="../script/jquery-3.6.0.min.js"></script>
     <script src="../script/semantic/semantic.min.js"></script>
   </head>
   <body>
-    <link rel="stylesheet" href="../darktheme.css">
+    <link rel="stylesheet" href="../darktheme.css" />
     <script src="../script/darktheme.js"></script>
     <br />
     <div class="ui container">
@@ -26,35 +26,54 @@
             <input type="checkbox" id="showUnexposed" class="hidden" />
             <label for="showUnexposed"
               >Show Containers with unexposed ports
-              <br />
-              <small
-                >Please make sure Zoraxy and the target container share a
-                network</small
-              >
             </label>
           </div>
         </div>
       </div>
+      <!--  Networked Containers Lists -->
       <div class="ui header">
         <div class="content">
-          List of Docker Containers
+          Networked Containers
           <div class="sub header">
-            Below is a list of all detected Docker containers currently running
-            on the system.
+            Containers sharing a network with Zoraxy.<br />
+            Docker DNS based name resolution has to be supported by your
+            network.
           </div>
         </div>
       </div>
-      <div id="containersList" class="ui middle aligned divided list active">
-        <div class="ui loader active"></div>
+      <div id="networkedList" class="ui middle aligned divided list">
+        <div class="ui active loader"></div>
       </div>
+      <!-- Host Mode Containers List -->
+      <div id="hostmodeListHeader" class="ui header" hidden>
+        <div class="content">
+          Host Mode Containers
+          <div class="sub header">
+            Containers using the host network.<br />Ports need to be added
+            manually.
+          </div>
+        </div>
+      </div>
+      <div id="hostmodeList" class="ui middle aligned divided list"></div>
       <div class="ui horizontal divider"></div>
-      <div id="containersAddedListHeader" class="ui header" hidden>
-        Already added containers:
+      <!-- Other Containers List -->
+      <div id="othersListHeader" class="ui header" hidden>
+        <div class="content">
+          Other Containers
+          <div class="sub header">
+            Containers that do not share a network with Zoraxy.<br />
+            Manual addition is required.
+          </div>
+        </div>
       </div>
-      <div
-        id="containersAddedList"
-        class="ui middle aligned divided list"
-      ></div>
+      <div id="othersList" class="ui middle aligned divided list"></div>
+      <div class="ui horizontal divider"></div>
+      <!-- Existing List -->
+      <div id="existingListHeader" class="ui header" hidden>
+        Existing Rules
+        <div class="sub header">Containers already in proxy rules.</div>
+      </div>
+      <div id="existingList" class="ui middle aligned divided list"></div>
     </div>
 
     <script>
@@ -69,14 +88,26 @@
 
       // wait until DOM is fully loaded before executing script
       $(document).ready(() => {
-        const $containersList = $("#containersList");
-        const $containersAddedList = $("#containersAddedList");
-        const $containersAddedListHeader = $("#containersAddedListHeader");
+        // jQuery objects for UI elements
+        const $networkedList = $("#networkedList");
+
+        const $hostmodeListHeader = $("#hostmodeListHeader");
+        const $hostmodeList = $("#hostmodeList");
+
+        const $othersListHeader = $("#othersListHeader");
+        const $othersList = $("#othersList");
+
+        const $existingListHeader = $("#existingListHeader");
+        const $existingList = $("#existingList");
+
         const $searchbar = $("#searchbar");
         const $showUnexposed = $("#showUnexposed");
 
-        let lines = {};
-        let linesAdded = {};
+        // objects to store container entries
+        let networkedEntries = {}; // { name, ip, port }
+        let hostmodeEntries = {}; // { name, ip }
+        let othersEntries = {}; // { name, ips, ports }
+        let existingEntries = {}; // { name, ip, port }
 
         // load showUnexposed checkbox state from local storage
         function loadShowUnexposedState() {
@@ -93,12 +124,21 @@
 
         // fetch docker containers
         function getDockerContainers() {
-          $containersList.html('<div class="ui loader active"></div>');
-          $containersAddedList.empty();
-          $containersAddedListHeader.attr("hidden", true);
+          $networkedList.html('<div class="ui active loader"></div>');
 
-          lines = {};
-          linesAdded = {};
+          $hostmodeListHeader.attr("hidden", true);
+          $hostmodeList.empty();
+
+          $othersListHeader.attr("hidden", true);
+          $othersList.empty();
+
+          $existingListHeader.attr("hidden", true);
+          $existingList.empty();
+
+          networkedEntries = {};
+          hostmodeEntries = {};
+          othersEntries = {};
+          existingEntries = {};
 
           const hostRequest = $.get("/api/proxy/list?type=host");
           const dockerRequest = $.get("/api/docker/containers");
@@ -126,73 +166,215 @@
             )
           );
 
+          // identify the Zoraxy container to determine shared networks
+          const zoraxyContainer = containers.find(
+            (container) =>
+              container.Labels &&
+              container.Labels["com.imuslab.zoraxy.container-identifier"] ===
+                "Zoraxy"
+          );
+
+          const zoraxyNetworkIDs = zoraxyContainer
+            ? Object.values(zoraxyContainer.NetworkSettings.Networks).map(
+                (network) => network.NetworkID
+              )
+            : [];
+
+          // process each container
           containers.forEach((container) => {
+            // skip containers in network mode "none"
+            if (container.HostConfig.NetworkMode === "none") {
+              return;
+            }
+
             const name = container.Names[0].replace(/^\//, "");
+
+            // host mode containers resolve to host.docker.internal
+            if (
+              container.HostConfig.NetworkMode === "host" &&
+              !hostmodeEntries[name]
+            ) {
+              hostmodeEntries[name] = {
+                name,
+                ip: "host.docker.internal",
+              };
+              return;
+            }
+
+            // check if the container shares a network with Zoraxy
+            const sharedNetworks = Object.values(
+              container.NetworkSettings.Networks
+            ).filter((network) => zoraxyNetworkIDs.includes(network.NetworkID));
+
+            // if the container does not share a network with Zoraxy, add it to the others list
+            if (!sharedNetworks.length) {
+              const ips = Object.values(container.NetworkSettings.Networks).map(
+                (network) => network.IPAddress
+              );
+
+              const ports = container.Ports.map((portObject) => {
+                return portObject.PublicPort || portObject.PrivatePort;
+              });
+
+              othersEntries[name] = {
+                name,
+                ips,
+                ports,
+              };
+              return;
+            }
+
+            // add the container to the networked list, using it's name as address
             container.Ports.forEach((portObject) => {
-              let port = portObject.PublicPort || portObject.PrivatePort;
+              // skip unexposed ports if the checkbox is not checked
               if (!portObject.PublicPort && !$showUnexposed.is(":checked"))
                 return;
 
-              // if port is not exposed, use container's name and let docker handle the routing
-              // BUT this will only work if the container is on the same network as Zoraxy
-              const targetAddress = portObject.IP || name;
-              const key = `${name}-${port}`;
+              const port = portObject.PublicPort || portObject.PrivatePort;
 
+              const key = `${name}:${port}`;
               if (
-                existingTargets.has(`${targetAddress}:${port}`) &&
-                !linesAdded[key]
+                existingTargets.has(`${name}:${port}`) &&
+                !existingEntries[key]
               ) {
-                linesAdded[key] = { name, ip: targetAddress, port };
-              } else if (!lines[key]) {
-                lines[key] = { name, ip: targetAddress, port };
+                existingEntries[key] = {
+                  name,
+                  ip: name,
+                  port,
+                };
+              } else if (!networkedEntries[key]) {
+                networkedEntries[key] = {
+                  name,
+                  ip: name,
+                  port,
+                };
               }
             });
           });
 
-          // update ui
-          updateContainersList();
-          updateAddedContainersList();
+          // update UI lists
+          updateNetworkedList();
+          updateHostmodeList();
+          updateOthersList();
+          updateExistingList();
         }
 
-        // update containers list
-        function updateContainersList() {
-          $containersList.empty();
-          Object.entries(lines).forEach(([key, line]) => {
-            $containersList.append(`
-              <div class="item">
-                <div class="right floated content">
-                  <div class="ui button add-button" data-key="${key}">Add</div>
+        // update networked list
+        function updateNetworkedList() {
+          $networkedList.empty();
+          let html = "";
+          Object.entries(networkedEntries)
+            .sort()
+            .forEach(([key, entry]) => {
+              html += `
+                <div class="item">
+                  <div class="content" style="display: flex; justify-content: space-between;">
+                    <div>
+                      <div class="header">${entry.name}</div>
+                      <div class="description">
+                        <p>${entry.ip}:${entry.port}</p>
+                      </div>
+                    </div>
+                    <button class="ui button add-button" data-key="${key}">
+                      Add
+                    </button>
+                  </div>
                 </div>
-                <div class="content">
-                  <div class="header">${line.name}</div>
-                  <div class="description">${line.ip}:${line.port}</div>
-                </div>
-              </div>
-            `);
-          });
-          $containersList.find(".loader").removeClass("active");
+              `;
+            });
+          $networkedList.append(html);
         }
 
-        // update the added containers list
-        function updateAddedContainersList() {
-          Object.entries(linesAdded).forEach(([key, line]) => {
-            $containersAddedList.append(`
-              <div class="item">
-                <div class="content">
-                  <div class="header">${line.name}</div>
-                  <div class="description">${line.ip}:${line.port}</div>
+        // update hostmode list
+        function updateHostmodeList() {
+          $hostmodeList.empty();
+          let html = "";
+          Object.entries(hostmodeEntries)
+            .sort()
+            .forEach(([key, entry]) => {
+              html += `
+                <div class="item">
+                  <div class="content" style="display: flex; justify-content: space-between;">
+                    <div>
+                      <div class="header">${entry.name}</div>
+                      <div class="description">
+                        <p>${entry.ip}</p>
+                      </div>
+                    </div>
+                    <button class="ui right floated button add-button" data-key="${key}">
+                      Add
+                    </button>
+                  </div>
                 </div>
-              </div>
-            `);
-          });
-          if (Object.keys(linesAdded).length) {
-            $containersAddedListHeader.removeAttr("hidden");
+              `;
+            });
+          $hostmodeList.append(html);
+          if (Object.keys(hostmodeEntries).length) {
+            $hostmodeListHeader.removeAttr("hidden");
+          }
+        }
+
+        // update others list
+        function updateOthersList() {
+          $othersList.empty();
+          let html = "";
+          Object.entries(othersEntries)
+            .sort()
+            .forEach(([key, entry]) => {
+              html += `
+                <div class="item">
+                  <div class="header">${entry.name}</div>
+                  ${
+                    entry.ips.length === 0 ||
+                    entry.ips.every((ip) => ip === "") ||
+                    entry.ports.length === 0 ||
+                    entry.ports.every((port) => port === "")
+                      ? `<div class="description">
+                          <p>No IPs or Ports</p>
+                        </div>`
+                      : `<div class="description">
+                        <p>
+                          IPs: ${entry.ips.join(", ")}<br />
+                          Ports: ${entry.ports.join(", ")}
+                        </p>
+                      </div>`
+                  }
+                </div>
+              `;
+            });
+          $othersList.append(html);
+          if (Object.keys(othersEntries).length) {
+            $othersListHeader.removeAttr("hidden");
+          }
+        }
+
+        // update existing list
+        function updateExistingList() {
+          $existingList.empty();
+          let html = "";
+          Object.entries(existingEntries)
+            .sort()
+            .forEach(([key, entry]) => {
+              html += `
+                <div class="item">
+                  <div class="content">
+                    <div class="header">${entry.name}</div>
+                    <div class="description">
+                      <p>${entry.ip}:${entry.port}</p>
+                    </div>
+                  </div>
+                </div>
+              `;
+            });
+          $existingList.append(html);
+          if (Object.keys(existingEntries).length) {
+            $existingListHeader.removeAttr("hidden");
           }
         }
 
         // show error message
         function showError(error) {
-          $containersList.html(
+          $networkedList.html(
             `<div class="ui basic segment"><i class="ui red times icon"></i> ${error}</div>`
           );
           parent.msgbox(`Error loading data: ${error}`, false);
@@ -207,23 +389,46 @@
           getDockerContainers();
         });
 
+        // debounce searchbar input with 300ms delay, then filter list
+        // this prevents excessive calls to the filter function
         $searchbar.on(
           "input",
           debounce(() => {
-            // debounce searchbar input with 300ms delay, then filter list
-            // this prevents excessive calls to the filter function
             const search = $searchbar.val().toLowerCase();
-            $("#containersList .item").each((index, item) => {
+
+            $("#networkedList .item").each((index, item) => {
+              const content = $(item).text().toLowerCase();
+              $(item).toggle(content.includes(search));
+            });
+
+            $("#hostmodeList .item").each((index, item) => {
+              const content = $(item).text().toLowerCase();
+              $(item).toggle(content.includes(search));
+            });
+
+            $("#othersList .item").each((index, item) => {
+              const content = $(item).text().toLowerCase();
+              $(item).toggle(content.includes(search));
+            });
+
+            $("#existingList .item").each((index, item) => {
               const content = $(item).text().toLowerCase();
               $(item).toggle(content.includes(search));
             });
           }, 300)
         );
 
-        $containersList.on("click", ".add-button", (event) => {
+        $networkedList.on("click", ".add-button", (event) => {
           const key = $(event.currentTarget).data("key");
-          if (lines[key]) {
-            parent.addContainerItem(lines[key]);
+          if (networkedEntries[key]) {
+            parent.addContainerItem(networkedEntries[key]);
+          }
+        });
+
+        $hostmodeList.on("click", ".add-button", (event) => {
+          const key = $(event.currentTarget).data("key");
+          if (hostmodeEntries[key]) {
+            parent.addContainerItem(hostmodeEntries[key]);
           }
         });
 

--- a/src/web/snippet/dockerContainersList.html
+++ b/src/web/snippet/dockerContainersList.html
@@ -31,8 +31,8 @@
           <div class="ui checkbox">
             <input type="checkbox" id="showUnexposed" class="hidden" />
             <label for="showUnexposed"
-              >Show Containers with unexposed ports
-            </label>
+              >Show Containers with unexposed ports</label
+            >
           </div>
         </div>
       </div>
@@ -50,6 +50,7 @@
       <div id="networkedList" class="ui middle aligned divided list">
         <div class="ui active loader"></div>
       </div>
+      <div class="ui horizontal divider"></div>
       <!-- Host Mode Containers List -->
       <div id="hostmodeListHeader" class="ui header" hidden>
         <div class="content">
@@ -81,378 +82,53 @@
       </div>
       <div id="existingList" class="ui middle aligned divided list"></div>
     </div>
-
     <script>
-      // debounce function to prevent excessive calls to a function
-      function debounce(func, delay) {
-        let timeout;
-        return (...args) => {
-          clearTimeout(timeout);
-          timeout = setTimeout(() => func(...args), delay);
-        };
-      }
+      // DOM elements
+      const $networkedList = $("#networkedList");
 
-      // wait until DOM is fully loaded before executing script
+      const $hostmodeListHeader = $("#hostmodeListHeader");
+      const $hostmodeList = $("#hostmodeList");
+
+      const $othersListHeader = $("#othersListHeader");
+      const $othersList = $("#othersList");
+
+      const $existingListHeader = $("#existingListHeader");
+      const $existingList = $("#existingList");
+
+      const $searchbar = $("#searchbar");
+      const $showOnlyRunning = $("#showOnlyRunning");
+      const $showUnexposed = $("#showUnexposed");
+
+      // maps for containers
+      let networkedEntries = {};
+      let hostmodeEntries = {};
+      let othersEntries = {};
+      let existingEntries = {};
+
+      // initial load
       $(document).ready(() => {
-        // jQuery objects for UI elements
-        const $networkedList = $("#networkedList");
+        loadCheckboxState("showUnexposed", $showUnexposed);
+        loadCheckboxState("showOnlyRunning", $showOnlyRunning);
+        initializeEventListeners();
+        getDockerContainers();
+      });
 
-        const $hostmodeListHeader = $("#hostmodeListHeader");
-        const $hostmodeList = $("#hostmodeList");
-
-        const $othersListHeader = $("#othersListHeader");
-        const $othersList = $("#othersList");
-
-        const $existingListHeader = $("#existingListHeader");
-        const $existingList = $("#existingList");
-
-        const $searchbar = $("#searchbar");
-        const $showOnlyRunning = $("#showOnlyRunning");
-        const $showUnexposed = $("#showUnexposed");
-
-        // objects to store container entries
-        let networkedEntries = {}; // { name, ip, port }
-        let hostmodeEntries = {}; // { name, ip }
-        let othersEntries = {}; // { name, ips, ports }
-        let existingEntries = {}; // { name, ip, port }
-
-        // load showUnexposed checkbox state from local storage
-        function loadShowUnexposedState() {
-          const storedState = localStorage.getItem("showUnexposed");
-          if (storedState !== null) {
-            $showUnexposed.prop("checked", storedState === "true");
-          }
-        }
-
-        // save showUnexposed checkbox state to local storage
-        function saveShowUnexposedState() {
-          localStorage.setItem("showUnexposed", $showUnexposed.prop("checked"));
-        }
-
-        // load showOnlyRunning checkbox state from local storage
-        function loadShowOnlyRunningState() {
-          const storedState = localStorage.getItem("showOnlyRunning");
-          if (storedState !== null) {
-            $showOnlyRunning.prop("checked", storedState === "true");
-          }
-        }
-
-        // save showOnlyRunning checkbox state to local storage
-        function saveShowOnlyRunningState() {
-          localStorage.setItem(
-            "showOnlyRunning",
-            $showOnlyRunning.prop("checked")
-          );
-        }
-
-        // fetch docker containers
-        function getDockerContainers() {
-          $networkedList.html('<div class="ui active loader"></div>');
-
-          $hostmodeListHeader.attr("hidden", true);
-          $hostmodeList.empty();
-
-          $othersListHeader.attr("hidden", true);
-          $othersList.empty();
-
-          $existingListHeader.attr("hidden", true);
-          $existingList.empty();
-
-          networkedEntries = {};
-          hostmodeEntries = {};
-          othersEntries = {};
-          existingEntries = {};
-
-          const hostRequest = $.get("/api/proxy/list?type=host");
-          const dockerRequest = $.get("/api/docker/containers");
-
-          Promise.all([hostRequest, dockerRequest])
-            .then(([hostData, dockerData]) => {
-              if (!hostData.error && !dockerData.error) {
-                processDockerData(hostData, dockerData);
-              } else {
-                showError(hostData.error || dockerData.error);
-              }
-            })
-            .catch((error) => {
-              console.error(error);
-              parent.msgbox("Error loading data: " + error.message, false);
-            });
-        }
-
-        // process docker data and update ui
-        function processDockerData(hostData, dockerData) {
-          const { containers } = dockerData;
-          const existingTargets = new Set(
-            hostData.flatMap(({ ActiveOrigins }) =>
-              ActiveOrigins.map(({ OriginIpOrDomain }) => OriginIpOrDomain)
-            )
-          );
-
-          // identify the Zoraxy container to determine shared networks
-          const zoraxyContainer = containers.find(
-            (container) =>
-              container.Labels &&
-              container.Labels["com.imuslab.zoraxy.container-identifier"] ===
-                "Zoraxy"
-          );
-
-          const zoraxyNetworkIDs = zoraxyContainer
-            ? Object.values(zoraxyContainer.NetworkSettings.Networks).map(
-                (network) => network.NetworkID
-              )
-            : [];
-
-          // process each container
-          containers.forEach((container) => {
-            // skip containers that are not running, if the checkbox is checked
-            if (
-              $showOnlyRunning.is(":checked") &&
-              container.State !== "running"
-            ) {
-              return;
-            }
-
-            // skip containers in network mode "none"
-            if (container.HostConfig.NetworkMode === "none") {
-              return;
-            }
-
-            const name = container.Names[0].replace(/^\//, "");
-
-            // host mode containers resolve to host.docker.internal
-            if (
-              container.HostConfig.NetworkMode === "host" &&
-              !hostmodeEntries[name]
-            ) {
-              hostmodeEntries[name] = {
-                name,
-                ip: "host.docker.internal",
-              };
-              return;
-            }
-
-            // check if the container shares a network with Zoraxy
-            const sharedNetworks = Object.values(
-              container.NetworkSettings.Networks
-            ).filter((network) => zoraxyNetworkIDs.includes(network.NetworkID));
-
-            // if the container does not share a network with Zoraxy, add it to the others list
-            if (!sharedNetworks.length) {
-              const ips = Object.values(container.NetworkSettings.Networks).map(
-                (network) => network.IPAddress
-              );
-
-              const ports = container.Ports.map((portObject) => {
-                return portObject.PublicPort || portObject.PrivatePort;
-              });
-
-              othersEntries[name] = {
-                name,
-                ips,
-                ports,
-              };
-              return;
-            }
-
-            // add the container to the networked list, using it's name as address
-            container.Ports.forEach((portObject) => {
-              // skip unexposed ports if the checkbox is not checked
-              if (!portObject.PublicPort && !$showUnexposed.is(":checked")) {
-                return;
-              }
-
-              const port = portObject.PublicPort || portObject.PrivatePort;
-
-              const key = `${name}:${port}`;
-              if (
-                existingTargets.has(`${name}:${port}`) &&
-                !existingEntries[key]
-              ) {
-                existingEntries[key] = {
-                  name,
-                  ip: name,
-                  port,
-                };
-              } else if (!networkedEntries[key]) {
-                networkedEntries[key] = {
-                  name,
-                  ip: name,
-                  port,
-                };
-              }
-            });
-          });
-
-          // update UI lists
-          updateNetworkedList();
-          updateHostmodeList();
-          updateOthersList();
-          updateExistingList();
-        }
-
-        // update networked list
-        function updateNetworkedList() {
-          $networkedList.empty();
-          let html = "";
-          Object.entries(networkedEntries)
-            .sort()
-            .forEach(([key, entry]) => {
-              html += `
-                <div class="item">
-                  <div class="content" style="display: flex; justify-content: space-between;">
-                    <div>
-                      <div class="header">${entry.name}</div>
-                      <div class="description">
-                        <p>${entry.ip}:${entry.port}</p>
-                      </div>
-                    </div>
-                    <button class="ui button add-button" data-key="${key}">
-                      Add
-                    </button>
-                  </div>
-                </div>
-              `;
-            });
-          $networkedList.append(html);
-        }
-
-        // update hostmode list
-        function updateHostmodeList() {
-          $hostmodeList.empty();
-          let html = "";
-          Object.entries(hostmodeEntries)
-            .sort()
-            .forEach(([key, entry]) => {
-              html += `
-                <div class="item">
-                  <div class="content" style="display: flex; justify-content: space-between;">
-                    <div>
-                      <div class="header">${entry.name}</div>
-                      <div class="description">
-                        <p>${entry.ip}</p>
-                      </div>
-                    </div>
-                    <button class="ui right floated button add-button" data-key="${key}">
-                      Add
-                    </button>
-                  </div>
-                </div>
-              `;
-            });
-          $hostmodeList.append(html);
-          if (Object.keys(hostmodeEntries).length) {
-            $hostmodeListHeader.removeAttr("hidden");
-          }
-        }
-
-        // update others list
-        function updateOthersList() {
-          $othersList.empty();
-          let html = "";
-          Object.entries(othersEntries)
-            .sort()
-            .forEach(([key, entry]) => {
-              html += `
-                <div class="item">
-                  <div class="header">${entry.name}</div>
-                  ${
-                    entry.ips.length === 0 ||
-                    entry.ips.every((ip) => ip === "") ||
-                    entry.ports.length === 0 ||
-                    entry.ports.every((port) => port === "")
-                      ? `<div class="description">
-                          <p>No IPs or Ports</p>
-                        </div>`
-                      : `<div class="description">
-                        <p>
-                          IPs: ${entry.ips.join(", ")}<br />
-                          Ports: ${entry.ports.join(", ")}
-                        </p>
-                      </div>`
-                  }
-                </div>
-              `;
-            });
-          $othersList.append(html);
-          if (Object.keys(othersEntries).length) {
-            $othersListHeader.removeAttr("hidden");
-          }
-        }
-
-        // update existing list
-        function updateExistingList() {
-          $existingList.empty();
-          let html = "";
-          Object.entries(existingEntries)
-            .sort()
-            .forEach(([key, entry]) => {
-              html += `
-                <div class="item">
-                  <div class="content">
-                    <div class="header">${entry.name}</div>
-                    <div class="description">
-                      <p>${entry.ip}:${entry.port}</p>
-                    </div>
-                  </div>
-                </div>
-              `;
-            });
-          $existingList.append(html);
-          if (Object.keys(existingEntries).length) {
-            $existingListHeader.removeAttr("hidden");
-          }
-        }
-
-        // show error message
-        function showError(error) {
-          $networkedList.html(
-            `<div class="ui basic segment"><i class="ui red times icon"></i> ${error}</div>`
-          );
-          parent.msgbox(`Error loading data: ${error}`, false);
-        }
-
-        //
-        // event listeners
-        //
-
+      // event listeners
+      function initializeEventListeners() {
         $showUnexposed.on("change", () => {
-          saveShowUnexposedState(); // save the new state to local storage
+          saveCheckboxState("showUnexposed", $showUnexposed);
           getDockerContainers();
         });
 
         $showOnlyRunning.on("change", () => {
-          saveShowOnlyRunningState(); // save the new state to local storage
+          saveCheckboxState("showOnlyRunning", $showOnlyRunning);
           getDockerContainers();
         });
 
-        // debounce searchbar input with 300ms delay, then filter list
-        // this prevents excessive calls to the filter function
+        // debounce searchbar input to prevent excessive filtering
         $searchbar.on(
           "input",
-          debounce(() => {
-            const search = $searchbar.val().toLowerCase();
-
-            $("#networkedList .item").each((index, item) => {
-              const content = $(item).text().toLowerCase();
-              $(item).toggle(content.includes(search));
-            });
-
-            $("#hostmodeList .item").each((index, item) => {
-              const content = $(item).text().toLowerCase();
-              $(item).toggle(content.includes(search));
-            });
-
-            $("#othersList .item").each((index, item) => {
-              const content = $(item).text().toLowerCase();
-              $(item).toggle(content.includes(search));
-            });
-
-            $("#existingList .item").each((index, item) => {
-              const content = $(item).text().toLowerCase();
-              $(item).toggle(content.includes(search));
-            });
-          }, 300)
+          debounce(() => filterLists($searchbar.val().toLowerCase()), 300)
         );
 
         $networkedList.on("click", ".add-button", (event) => {
@@ -468,17 +144,305 @@
             parent.addContainerItem(hostmodeEntries[key]);
           }
         });
+      }
+      // filter lists by toggling item visibility
+      function filterLists(searchTerm) {
+        $(".list .item").each((_, item) => {
+          const content = $(item).text().toLowerCase();
+          $(item).toggle(content.includes(searchTerm));
+        });
+      }
 
-        //
-        // initial calls
-        //
+      // reset UI and state
+      function reset() {
+        networkedEntries = {};
+        hostmodeEntries = {};
+        othersEntries = {};
+        existingEntries = {};
 
-        // load state of showUnexposed checkbox
-        loadShowUnexposedState();
+        $networkedList.empty();
+        $hostmodeList.empty();
+        $othersList.empty();
+        $existingList.empty();
 
-        // initial load of docker containers
-        getDockerContainers();
-      });
+        $hostmodeListHeader.attr("hidden", true);
+        $othersListHeader.attr("hidden", true);
+        $existingListHeader.attr("hidden", true);
+      }
+
+      // process docker data
+      async function getDockerContainers() {
+        reset();
+        $networkedList.html('<div class="ui active loader"></div>');
+
+        try {
+          const [hostData, dockerData] = await Promise.all([
+            $.get("/api/proxy/list?type=host"),
+            $.get("/api/docker/containers"),
+          ]);
+          if (!hostData.error && !dockerData.error) {
+            processDockerData(hostData, dockerData);
+          } else {
+            showError(hostData.error || dockerData.error);
+          }
+        } catch (error) {
+          console.error(error);
+          parent.msgbox("Error loading data: " + error.message, false);
+        }
+      }
+
+      function processDockerData(hostData, dockerData) {
+        const { containers } = dockerData;
+        const existingTargets = new Set(
+          hostData.flatMap(({ ActiveOrigins }) =>
+            ActiveOrigins.map(({ OriginIpOrDomain }) => OriginIpOrDomain)
+          )
+        );
+
+        // identify the Zoraxy container to determine shared networks
+        const zoraxyContainer = containers.find(
+          (container) =>
+            container.Labels &&
+            container.Labels["com.imuslab.zoraxy.container-identifier"] ===
+              "Zoraxy"
+        );
+
+        const zoraxyNetworkIDs = zoraxyContainer
+          ? Object.values(zoraxyContainer.NetworkSettings.Networks).map(
+              (network) => network.NetworkID
+            )
+          : [];
+
+        // iterate over all containers
+        containers.forEach((container) => {
+          // skip containers in network mode "none"
+          if (container.HostConfig.NetworkMode === "none") {
+            return;
+          }
+
+          // skip containers not running, if the option is enabled
+          if (
+            container.State !== "running" &&
+            $showOnlyRunning.prop("checked")
+          ) {
+            return;
+          }
+
+          // sanitize container name
+          const containerName = container.Names[0].replace(/^\//, "");
+
+          // containers in network mode "host" should resolve to "host.docker.internal"
+          if (
+            container.HostConfig.NetworkMode === "host" &&
+            !hostmodeEntries[container.Id]
+          ) {
+            hostmodeEntries[container.Id] = {
+              name: containerName,
+              ip: "host.docker.internal",
+            };
+            return;
+          }
+
+          // networks that are shared with Zoraxy
+          const sharedNetworks = Object.values(
+            container.NetworkSettings.Networks
+          ).filter((network) => zoraxyNetworkIDs.includes(network.NetworkID));
+
+          if (!sharedNetworks.length) {
+            const ips = Object.values(container.NetworkSettings.Networks).map(
+              (network) => network.IPAddress
+            );
+
+            const ports = container.Ports.map((portObject) => {
+              return portObject.PublicPort || portObject.PrivatePort;
+            });
+
+            othersEntries[container.Id] = {
+              name: containerName,
+              ips,
+              ports,
+            };
+            return;
+          }
+
+          // add the container to the networked list, using it's name as address
+          container.Ports.forEach((portObject) => {
+            // skip unexposed ports if the checkbox is not checked
+            if (!portObject.PublicPort && !$showUnexposed.is(":checked")) {
+              return;
+            }
+
+            const port = portObject.PublicPort || portObject.PrivatePort;
+            const key = `${containerName}:${port}`;
+
+            if (existingTargets.has(key) && !existingEntries[key]) {
+              existingEntries[key] = {
+                name: containerName,
+                ip: containerName,
+                port,
+              };
+            } else if (!networkedEntries[key]) {
+              networkedEntries[key] = {
+                name: containerName,
+                ip: containerName,
+                port,
+              };
+            }
+          });
+        });
+
+        // finally update the UI
+        updateNetworkedList();
+        updateHostmodeList();
+        updateOthersList();
+        updateExistingList();
+      }
+
+      // update networked list
+      function updateNetworkedList() {
+        $networkedList.empty();
+        let html = "";
+        Object.entries(networkedEntries)
+          .sort()
+          .forEach(([key, entry]) => {
+            html += `
+              <div class="item">
+                <div class="content" style="display: flex; justify-content: space-between;">
+                  <div>
+                    <div class="header">${entry.name}</div>
+                    <div class="description">
+                      <p>${entry.ip}:${entry.port}</p>
+                    </div>
+                  </div>
+                  <button class="ui button add-button" data-key="${key}">
+                    Add
+                  </button>
+                </div>
+              </div>
+            `;
+          });
+        $networkedList.append(html);
+      }
+
+      // update hostmode list
+      function updateHostmodeList() {
+        $hostmodeList.empty();
+        let html = "";
+        Object.entries(hostmodeEntries)
+          .sort()
+          .forEach(([key, entry]) => {
+            html += `
+              <div class="item">
+                <div class="content" style="display: flex; justify-content: space-between;">
+                  <div>
+                    <div class="header">${entry.name}</div>
+                    <div class="description">
+                      <p>${entry.ip}</p>
+                    </div>
+                  </div>
+                  <button class="ui right floated button add-button" data-key="${key}">
+                    Add
+                  </button>
+                </div>
+              </div>
+            `;
+          });
+        $hostmodeList.append(html);
+        if (Object.keys(hostmodeEntries).length) {
+          $hostmodeListHeader.removeAttr("hidden");
+        }
+      }
+
+      // update others list
+      function updateOthersList() {
+        $othersList.empty();
+        let html = "";
+        Object.entries(othersEntries)
+          .sort()
+          .forEach(([key, entry]) => {
+            html += `
+              <div class="item">
+                <div class="header">${entry.name}</div>
+                ${
+                  entry.ips.length === 0 ||
+                  entry.ips.every((ip) => ip === "") ||
+                  entry.ports.length === 0 ||
+                  entry.ports.every((port) => port === "")
+                    ? `<div class="description">
+                        <p>No IPs or Ports</p>
+                      </div>`
+                    : `<div class="description">
+                      <p>
+                        IPs: ${entry.ips.join(", ")}<br />
+                        Ports: ${entry.ports.join(", ")}
+                      </p>
+                    </div>`
+                }
+              </div>
+            `;
+          });
+        $othersList.append(html);
+        if (Object.keys(othersEntries).length) {
+          $othersListHeader.removeAttr("hidden");
+        }
+      }
+
+      // update existing rules list
+      function updateExistingList() {
+        $existingList.empty();
+        let html = "";
+        Object.entries(existingEntries)
+          .sort()
+          .forEach(([key, entry]) => {
+            html += `
+              <div class="item">
+                <div class="content">
+                  <div class="header">${entry.name}</div>
+                  <div class="description">
+                    <p>${entry.ip}:${entry.port}</p>
+                  </div>
+                </div>
+              </div>
+            `;
+          });
+        $existingList.append(html);
+        if (Object.keys(existingEntries).length) {
+          $existingListHeader.removeAttr("hidden");
+        }
+      }
+
+      // show error message
+      function showError(error) {
+        $networkedList.html(
+          `<div class="ui basic segment"><i class="ui red times icon"></i> ${error}</div>`
+        );
+        parent.msgbox(`Error loading data: ${error}`, false);
+      }
+
+      //
+      // utils
+      //
+
+      // local storage handling
+      function loadCheckboxState(id, $elem) {
+        const state = localStorage.getItem(id);
+        if (state !== null) {
+          $elem.prop("checked", state === "true");
+        }
+      }
+      
+      function saveCheckboxState(id, $elem) {
+        localStorage.setItem(id, $elem.prop("checked"));
+      }
+
+      // debounce function
+      function debounce(func, delay) {
+        let timeout;
+        return (...args) => {
+          clearTimeout(timeout);
+          timeout = setTimeout(() => func(...args), delay);
+        };
+      }
     </script>
   </body>
 </html>

--- a/src/web/snippet/dockerContainersList.html
+++ b/src/web/snippet/dockerContainersList.html
@@ -23,6 +23,12 @@
         </div>
         <div class="field">
           <div class="ui checkbox">
+            <input type="checkbox" id="showOnlyRunning" class="hidden" />
+            <label for="showOnlyRunning">Show running Containers only</label>
+          </div>
+        </div>
+        <div class="field">
+          <div class="ui checkbox">
             <input type="checkbox" id="showUnexposed" class="hidden" />
             <label for="showUnexposed"
               >Show Containers with unexposed ports
@@ -101,6 +107,7 @@
         const $existingList = $("#existingList");
 
         const $searchbar = $("#searchbar");
+        const $showOnlyRunning = $("#showOnlyRunning");
         const $showUnexposed = $("#showUnexposed");
 
         // objects to store container entries
@@ -120,6 +127,22 @@
         // save showUnexposed checkbox state to local storage
         function saveShowUnexposedState() {
           localStorage.setItem("showUnexposed", $showUnexposed.prop("checked"));
+        }
+
+        // load showOnlyRunning checkbox state from local storage
+        function loadShowOnlyRunningState() {
+          const storedState = localStorage.getItem("showOnlyRunning");
+          if (storedState !== null) {
+            $showOnlyRunning.prop("checked", storedState === "true");
+          }
+        }
+
+        // save showOnlyRunning checkbox state to local storage
+        function saveShowOnlyRunningState() {
+          localStorage.setItem(
+            "showOnlyRunning",
+            $showOnlyRunning.prop("checked")
+          );
         }
 
         // fetch docker containers
@@ -182,6 +205,14 @@
 
           // process each container
           containers.forEach((container) => {
+            // skip containers that are not running, if the checkbox is checked
+            if (
+              $showOnlyRunning.is(":checked") &&
+              container.State !== "running"
+            ) {
+              return;
+            }
+
             // skip containers in network mode "none"
             if (container.HostConfig.NetworkMode === "none") {
               return;
@@ -227,8 +258,9 @@
             // add the container to the networked list, using it's name as address
             container.Ports.forEach((portObject) => {
               // skip unexposed ports if the checkbox is not checked
-              if (!portObject.PublicPort && !$showUnexposed.is(":checked"))
+              if (!portObject.PublicPort && !$showUnexposed.is(":checked")) {
                 return;
+              }
 
               const port = portObject.PublicPort || portObject.PrivatePort;
 
@@ -386,6 +418,11 @@
 
         $showUnexposed.on("change", () => {
           saveShowUnexposedState(); // save the new state to local storage
+          getDockerContainers();
+        });
+
+        $showOnlyRunning.on("change", () => {
+          saveShowOnlyRunningState(); // save the new state to local storage
           getDockerContainers();
         });
 

--- a/src/web/snippet/dockerContainersList.html
+++ b/src/web/snippet/dockerContainersList.html
@@ -268,26 +268,28 @@
 
           // add the container to the networked list, using it's name as address
           container.Ports.forEach((portObject) => {
-            // skip unexposed ports if the checkbox is not checked
-            if (!portObject.PublicPort && !$showUnexposed.is(":checked")) {
-              return;
-            }
-
             const port = portObject.PublicPort || portObject.PrivatePort;
             const key = `${containerName}:${port}`;
 
-            if (existingTargets.has(key) && !existingEntries[key]) {
-              existingEntries[key] = {
-                name: containerName,
-                ip: containerName,
-                port,
-              };
-            } else if (!networkedEntries[key]) {
-              networkedEntries[key] = {
-                name: containerName,
-                ip: containerName,
-                port,
-              };
+            // always include existing proxy-rule targets
+            if (existingTargets.has(key)) {
+              if (!existingEntries[key]) {
+                existingEntries[key] = {
+                  name: containerName,
+                  ip: containerName,
+                  port,
+                };
+              }
+            }
+            // otherwise, include only if exposed or checkbox is checked
+            else if (portObject.PublicPort || $showUnexposed.is(":checked")) {
+              if (!networkedEntries[key]) {
+                networkedEntries[key] = {
+                  name: containerName,
+                  ip: containerName,
+                  port,
+                };
+              }
             }
           });
         });

--- a/src/web/snippet/dockerContainersList.html
+++ b/src/web/snippet/dockerContainersList.html
@@ -17,21 +17,21 @@
           <input
             id="searchbar"
             type="text"
-            placeholder="Search..."
+            placeholder="Search Containers ..."
             autocomplete="off"
           />
         </div>
         <div class="field">
           <div class="ui checkbox">
             <input type="checkbox" id="showOnlyRunning" class="hidden" />
-            <label for="showOnlyRunning">Show running Containers only</label>
+            <label for="showOnlyRunning">Show Only Running Containers</label>
           </div>
         </div>
         <div class="field">
           <div class="ui checkbox">
             <input type="checkbox" id="showUnexposed" class="hidden" />
             <label for="showUnexposed"
-              >Show Containers with unexposed ports</label
+              >Show Containers with Unexposed Ports</label
             >
           </div>
         </div>
@@ -39,11 +39,10 @@
       <!--  Networked Containers Lists -->
       <div class="ui header">
         <div class="content">
-          Networked Containers
+          Containers on Zoraxy's Networks
           <div class="sub header">
-            Containers sharing a network with Zoraxy.<br />
-            Docker DNS based name resolution has to be supported by your
-            network.
+            These containers share a network with Zoraxy.<br />
+            Your networks must support Docker DNS-based name resolution.
           </div>
         </div>
       </div>
@@ -54,10 +53,10 @@
       <!-- Host Mode Containers List -->
       <div id="hostmodeListHeader" class="ui header" hidden>
         <div class="content">
-          Host Mode Containers
+          Containers using Host Network
           <div class="sub header">
-            Containers using the host network.<br />Ports need to be added
-            manually.
+            These containers use the host network configuration.<br />
+            Ports must be manually configured.
           </div>
         </div>
       </div>
@@ -66,10 +65,10 @@
       <!-- Other Containers List -->
       <div id="othersListHeader" class="ui header" hidden>
         <div class="content">
-          Other Containers
+          Containers on different Networks
           <div class="sub header">
-            Containers that do not share a network with Zoraxy.<br />
-            Manual addition is required.
+            These containers are not connected to Zoraxy's networks.<br />
+            Manual configuration is required.
           </div>
         </div>
       </div>
@@ -77,8 +76,10 @@
       <div class="ui horizontal divider"></div>
       <!-- Existing List -->
       <div id="existingListHeader" class="ui header" hidden>
-        Existing Rules
-        <div class="sub header">Containers already in proxy rules.</div>
+        Containers with existing Proxy Rules
+        <div class="sub header">
+          These containers are already configured in the proxy rules.
+        </div>
       </div>
       <div id="existingList" class="ui middle aligned divided list"></div>
     </div>
@@ -430,7 +431,7 @@
           $elem.prop("checked", state === "true");
         }
       }
-      
+
       function saveCheckboxState(id, $elem) {
         localStorage.setItem(id, $elem.prop("checked"));
       }


### PR DESCRIPTION
This PR enhances the Docker container list by reorganizing the UI and improving stability.

### Changes
#### UI enhancements
- **Section headings & grouping**  
  Containers are now split into four logical groups, each reflecting how Zoraxy can reach them:
  1. **Containers on Zoraxy’s Networks**  
     Supported via Docker DNS–based name resolution  
  2. **Containers using Host Network**  
     Supported using `host.docker.internal` to access the host’s network gateway (ports must be entered manually)  
  3. **Containers on different Networks**  
     Any other Docker network (address + ports must be entered manually)  
  4. **Containers with existing Proxy Rules**  
     Containers already configured with proxy mappings  
- **Running-only filter**  
  Added a **Show Only Running Containers** checkbox to hide stopped or paused containers

#### Core changes
- **Container self-label**  
  Zoraxy’s own container now carries a label for easy in-container identification  
- **Host gateway resolution**  
  Injects `host.docker.internal:host-gateway` so Zoraxy resolves the Docker host’s gateway IP seamlessly
- **API version negotiation**  
  Enables Docker-client version negotiation to avoid errors when daemon and client differ

### Related issues
- Closes #462 — containers now listed by reachability (manual config still required for networks out of Zoraxy’s reach)  
- Fixes #639 — Docker API negotiation replaces hard-coded client version

If you have any questions or suggestions, feel free to reach out.