### PR TITLE
fix empty sso advanced parameters

### DIFF
--- a/src/mod/auth/sso/forward/forward.go
+++ b/src/mod/auth/sso/forward/forward.go
@@ -58,11 +58,20 @@ func NewAuthRouter(options *AuthRouterOptions) *AuthRouter {
 	options.Database.Read(DatabaseTable, DatabaseKeyRequestIncludedCookies, &requestIncludedCookies)
 	options.Database.Read(DatabaseTable, DatabaseKeyRequestExcludedCookies, &requestExcludedCookies)
 
-	options.ResponseHeaders = strings.Split(responseHeaders, ",")
-	options.ResponseClientHeaders = strings.Split(responseClientHeaders, ",")
-	options.RequestHeaders = strings.Split(requestHeaders, ",")
-	options.RequestIncludedCookies = strings.Split(requestIncludedCookies, ",")
-	options.RequestExcludedCookies = strings.Split(requestExcludedCookies, ",")
+	// Helper function to clean empty strings from split results
+	cleanSplit := func(s string) []string {
+		parts := strings.Split(s, ",")
+		if len(parts) == 1 && parts[0] == "" {
+			return []string{}
+		}
+		return parts
+	}
+
+	options.ResponseHeaders = cleanSplit(responseHeaders)
+	options.ResponseClientHeaders = cleanSplit(responseClientHeaders)
+	options.RequestHeaders = cleanSplit(requestHeaders)
+	options.RequestIncludedCookies = cleanSplit(requestIncludedCookies)
+	options.RequestExcludedCookies = cleanSplit(requestExcludedCookies)
 
 	return &AuthRouter{
 		client: &http.Client{

--- a/src/mod/auth/sso/forward/forward.go
+++ b/src/mod/auth/sso/forward/forward.go
@@ -60,11 +60,11 @@ func NewAuthRouter(options *AuthRouterOptions) *AuthRouter {
 
 	// Helper function to clean empty strings from split results
 	cleanSplit := func(s string) []string {
-		parts := strings.Split(s, ",")
-		if len(parts) == 1 && parts[0] == "" {
-			return []string{}
-		}
-		return parts
+	        if s == "" {
+	          return nil
+	        }
+
+		return strings.Split(s, ",")
 	}
 
 	options.ResponseHeaders = cleanSplit(responseHeaders)


### PR DESCRIPTION
Fix fetching of SSO Advanced Options: an empty string results in `[0] = ""`, leading to incorrect behavior when checking `len() === 0`