### PR TITLE
Fix Stream Proxy TCP/UDP selection not saved initially #742

### DIFF
--- a/src/web/components/streamprox.html
+++ b/src/web/components/streamprox.html
@@ -137,7 +137,7 @@
         });
             
         function clearStreamProxyAddEditForm(){
-            $('#streamProxyForm input, #streamProxyForm select').val('');
+            $('#streamProxyForm').find('input:not([type=checkbox]), select').val('');
             $('#streamProxyForm select').dropdown('clear');
             $("#streamProxyForm input[name=timeout]").val(10);
             $("#streamProxyForm .toggle.checkbox").checkbox("set unchecked");


### PR DESCRIPTION
- Reset the value of the form correctly in `streamprox.html`. Ref #742.