### PR TITLE
feat(sso): forward auth body and alternate headers

### DIFF
--- a/src/mod/auth/sso/forward/const.go
+++ b/src/mod/auth/sso/forward/const.go
@@ -13,14 +13,21 @@ const (
 	DatabaseKeyRequestHeaders         = "requestHeaders"
 	DatabaseKeyRequestIncludedCookies = "requestIncludedCookies"
 	DatabaseKeyRequestExcludedCookies = "requestExcludedCookies"
+	DatabaseKeyRequestIncludeBody     = "requestIncludeBody"
+	DatabaseKeyUseXOriginalHeaders    = "useXOriginalHeaders"
 
 	HeaderXForwardedProto  = "X-Forwarded-Proto"
 	HeaderXForwardedHost   = "X-Forwarded-Host"
-	HeaderXForwardedFor    = "X-Forwarded-For"
 	HeaderXForwardedURI    = "X-Forwarded-URI"
+	HeaderXForwardedFor    = "X-Forwarded-For"
 	HeaderXForwardedMethod = "X-Forwarded-Method"
 
-	HeaderCookie = "Cookie"
+	HeaderXOriginalURL    = "X-Original-URL"
+	HeaderXOriginalIP     = "X-Original-IP"
+	HeaderXOriginalMethod = "X-Original-Method"
+
+	HeaderCookie   = "Cookie"
+	HeaderLocation = "Location"
 
 	HeaderUpgrade          = "Upgrade"
 	HeaderConnection       = "Connection"

--- a/src/web/components/sso.html
+++ b/src/web/components/sso.html
@@ -6,7 +6,7 @@
     <div class="ui divider"></div>
     <div class="ui top attached tabular menu ssoTabs">
         <a class="item active" data-tab="forward_auth_tab">Forward Auth</a>
-        <a class="item" data-tab="oauth2_tab">Oauth2</a>
+        <a class="item" data-tab="oauth2_tab">OAuth 2.0</a>
         <!-- <a class="item" data-tab="zoraxy_sso_tab">Zoraxy SSO</a> -->
         </div>
         <div class="ui bottom attached tab segment active" data-tab="forward_auth_tab">
@@ -28,7 +28,7 @@
             <div class="field">
                 <label for="forwardAuthAddress">Address</label>
                 <input type="text" id="forwardAuthAddress" name="forwardAuthAddress" placeholder="Enter Forward Auth Address">
-                <small>The full remote address or URL of the authorization servers forward auth endpoint. <strong>Example:</strong> https://auth.example.com/authz/forward-auth</small>
+                <small>The full remote address or URL of the authorization servers forward auth endpoint. <strong>Example:</strong> http://127.0.0.1:9091/authz/forward-auth</small>
             </div>
             <div class="ui basic segment advanceoptions" style="margin-top:0.6em;">
                 <div class="ui advancedSSOForwardAuthOptions accordion">
@@ -78,6 +78,14 @@
                                 <strong>Example:</strong> <code>authelia_session,another_session</code>
                             </small>
                         </div>
+                        <div class="ui checkbox">
+                            <input type="checkbox" id="forwardAuthRequestIncludeBody" name="forwardAuthRequestIncludeBody" value="Forward Auth Request Include Request Body">
+                            <label for="forwardAuthRequestIncludeBody">Forward Auth Request Include Request Body<br><small>This allows the request body from the <b><i>request made from the client</i></b> to be included in the <b><i>request made to the authorization server</i></b>. Generally this should not be enabled.</small></label>
+                        </div>
+                        <div class="ui checkbox">
+                            <input type="checkbox" id="forwardAuthRequestUseXOriginalHeaders" name="forwardAuthRequestUseXOriginalHeaders" value="Use X-Original-* Headers">
+                            <label for="forwardAuthRequestUseXOriginalHeaders">Use X-Original-* Headers<br><small>This is used for implementations which do not use the X-Forwarded-* headers. In addition if the authorization server responds with a 401 and Location header the status will be changed to 302.</small></label>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -85,7 +93,7 @@
         </form>
         </div>
         <div class="ui bottom attached tab segment" data-tab="oauth2_tab">
-        <!-- Oauth 2 -->
+        <!-- OAuth 2.0 -->
         <h2>OAuth 2.0</h2>
         <p>Configuration settings for OAuth 2.0 authentication provider.</p>
 
@@ -96,7 +104,7 @@
                 <small>Public identifier of the OAuth2 application</small>
             </div>
             <div class="field">
-                <label for="oauth2ClientId">Client Secret</label>
+                <label for="oauth2ClientSecret">Client Secret</label>
                 <input type="password" id="oauth2ClientSecret" name="oauth2ClientSecret" placeholder="Enter Client Secret">
                 <small>Secret key of the OAuth2 application</small>
             </div>
@@ -144,7 +152,7 @@
     $(".ssoTabs .item").tab();
 
     $(document).ready(function() {
-        /* Load forward-auth settings from backend */
+        /* Load Forward Authz settings from backend */
         $.cjax({
             url: '/api/sso/forward-auth',
             method: 'GET',
@@ -176,13 +184,23 @@
                 } else {
                     $('#forwardAuthRequestExcludedCookies').val("");
                 }
+                if (data.requestIncludeBody != null && data.requestIncludeBody === true) {
+                    $("#forwardAuthRequestIncludeBody").parent().checkbox("set checked");
+                } else {
+                    $("#forwardAuthRequestIncludeBody").parent().checkbox("set unchecked");
+                }
+                if (data.useXOriginalHeaders != null && data.useXOriginalHeaders === true) {
+                    $("#forwardAuthRequestUseXOriginalHeaders").parent().checkbox("set checked");
+                } else {
+                    $("#forwardAuthRequestUseXOriginalHeaders").parent().checkbox("set unchecked");
+                }
             },
             error: function(jqXHR, textStatus, errorThrown) {
                 console.error('Error fetching SSO settings:', textStatus, errorThrown);
             }
         });
 
-        /* Load Oauth2 settings from backend */
+        /* Load OAuth 2.0 settings from backend */
         $.cjax({
             url: '/api/sso/OAuth2',
             method: 'GET',
@@ -204,19 +222,22 @@
         /* Add more initialization code here if needed */
     });
 
-    /* 
-        Function to update Forward Auth settings.
+    /*
+        Forward Auth settings update handler.
     */
+    $("#forwardAuthSettings").on("submit", function(event) {
+        event.preventDefault();
 
-    function updateForwardAuthSettings() {
         const address = $('#forwardAuthAddress').val();
         const responseHeaders = $('#forwardAuthResponseHeaders').val();
         const responseClientHeaders = $('#forwardAuthResponseClientHeaders').val();
         const requestHeaders = $('#forwardAuthRequestHeaders').val();
         const requestIncludedCookies = $('#forwardAuthRequestIncludedCookies').val();
         const requestExcludedCookies = $('#forwardAuthRequestExcludedCookies').val();
+        const requestIncludeBody = $('#forwardAuthRequestIncludeBody').is(':checked');
+        const useXOriginalHeaders = $('#forwardAuthRequestUseXOriginalHeaders').is(':checked');
 
-        console.log(`Updating Forward Auth settings. Address: ${address}. Response Headers: ${responseHeaders}. Response Client Headers: ${responseClientHeaders}. Request Headers: ${requestHeaders}. Request Excluded Cookies: ${requestExcludedCookies}.`);
+        console.log(`Updating Forward Auth settings. Address: ${address}. Response Headers: ${responseHeaders}. Response Client Headers: ${responseClientHeaders}. Request Headers: ${requestHeaders}. Request Included Cookies: ${requestIncludedCookies}. Request Excluded Cookies: ${requestExcludedCookies}. Request Include Body: ${requestIncludeBody}. Use X-Original-* Headers: ${useXOriginalHeaders}.`);
 
         $.cjax({
             url: '/api/sso/forward-auth',
@@ -226,7 +247,10 @@
                 responseHeaders: responseHeaders,
                 responseClientHeaders: responseClientHeaders,
                 requestHeaders: requestHeaders,
-                requestExcludedCookies: requestExcludedCookies
+                requestIncludedCookies: requestIncludedCookies,
+                requestExcludedCookies: requestExcludedCookies,
+                requestIncludeBody: requestIncludeBody,
+                useXOriginalHeaders: useXOriginalHeaders,
             },
             success: function(data) {
                 if (data.error !== undefined) {
@@ -240,42 +264,11 @@
                 console.error('Error updating Forward Auth settings:', textStatus, errorThrown);
             }
         });
-    }
-
-    $("#forwardAuthSettings").on("submit", function(event) {
-        event.preventDefault();
-        updateForwardAuthSettings();
     });
 
     /*
-        Oauth2 settings update handler.
+        OAuth 2.0 settings update handler.
     */
-    $( "#authentikSettings" ).on( "submit", function( event ) {
-        event.preventDefault();
-        $.cjax({
-            url: '/api/sso/forward-auth',
-            method: 'POST',
-            data: {
-                address: address,
-                responseHeaders: responseHeaders,
-                responseClientHeaders: responseClientHeaders,
-                requestHeaders: requestHeaders,
-                requestExcludedCookies: requestExcludedCookies
-            },
-            success: function(data) {
-                if (data.error !== undefined) {
-                    msgbox(data.error, false);
-                    return;
-                }
-                msgbox('Forward Auth settings updated', true);
-                console.log('Forward Auth settings updated:', data);
-            },
-            error: function(jqXHR, textStatus, errorThrown) {
-                console.error('Error updating Forward Auth settings:', textStatus, errorThrown);
-            }
-        });
-    });
-
     $( "#oauth2Settings" ).on( "submit", function( event ) {
         event.preventDefault();
         $.cjax({


### PR DESCRIPTION
This implements a minor modification to the forward authz sso where the body can be copied to the auth server and the X-Original-* implementations can be used.