### PR TITLE
put plugin API on separate mux not protected by CSRF

### DIFF
--- a/example/plugins/plugin2plugin-comms-peer1/www/index.html
+++ b/example/plugins/plugin2plugin-comms-peer1/www/index.html
@@ -21,12 +21,12 @@
             z-index: 1000;
         }
         .sent-message {
-            background-color: #d4edda;
+            background-color: var(--theme_bg_primary);
             border-left: 5px solid #155724;
             animation: fadeIn 0.5s;
         }
         .received-message {
-            background-color: #cce5ff;
+            background-color: var(--theme_bg_secondary);
             border-left: 5px solid #004085;
             animation: fadeIn 0.5s;
         }

--- a/example/plugins/plugin2plugin-comms-peer2/www/index.html
+++ b/example/plugins/plugin2plugin-comms-peer2/www/index.html
@@ -21,12 +21,12 @@
             z-index: 1000;
         }
         .sent-message {
-            background-color: #d4edda;
+            background-color: var(--theme_bg_primary);
             border-left: 5px solid #155724;
             animation: fadeIn 0.5s;
         }
         .received-message {
-            background-color: #cce5ff;
+            background-color: var(--theme_bg_secondary);
             border-left: 5px solid #004085;
             animation: fadeIn 0.5s;
         }


### PR DESCRIPTION
fixes issue #819 by putting the plugin API on a separate mux that is not wrapped in the CSRF middleware