### PR TITLE
Update Sidebar CSS

### DIFF
--- a/src/web/darktheme.css
+++ b/src/web/darktheme.css
@@ -336,7 +336,7 @@ body.darkTheme .ui.segment.advanceoptions {
 body.darkTheme .ui.segment{
     background-color: transparent !important;
     color: var(--text_color) !important;
-    border: 1px solid transparent !important;
+    border: 0 /*solid transparent*/ !important;
 }
 
 body.darkTheme .sub.header {

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -173,7 +173,7 @@
         </div>
         <br><br>
         <div class="ui divider"></div>
-        <div class="ui container" style="color: grey; font-size: 90%">
+        <div class="ui container" style="color: grey; font-size: 90%; padding-bottom: 1em;">
             <p><a href="https://zoraxy.aroz.org" target="_blank">Zoraxy</a> <span class="zrversion"></span> © 2021 - <span class="year"></span> tobychui. Licensed under AGPL</p>
         </div>
         

--- a/src/web/main.css
+++ b/src/web/main.css
@@ -72,15 +72,17 @@ body.darkTheme .menubar{
     width: 240px;
     position: sticky;
     top: 4em;
+    padding: 0 1em;
 }
 
 .contentWindow{
     display: inline-block;
-    width: calc(100% - 240px);
+    width: calc(100% - 244px);
     vertical-align: top;
     background-color: var(--theme_bg_primary);
     border-radius: 1em;
-    margin-right: 2em;
+    margin-right: 1em;
+    flex-shrink: 0;
 }
 
 .menutoggle{
@@ -309,8 +311,17 @@ body.darkTheme .menubar{
     font-size: 0.8em !important;
     color: #9c9c9c !important;
     padding-left: 0.6em;
+    /* fix the divider being really weird in the sidebar menu */
+    margin: 1rem 0 0.25rem 0 !important;
+    height: 2em !important;
+    border-bottom: 1px solid rgba(34,36,38,.15) !important;
+    border-top: 1px solid rgba(255,255,255,.1) !important;
 }
 
+body.darkTheme .menudivider{
+    border-bottom: 1px solid rgba(255,255,255,.15) !important;
+    border-top: 1px solid rgba(34,36,38,.1) !important;
+}
 /*
     Global rules overwrite
 */


### PR DESCRIPTION
I started setting up Zoraxy earlier today and there were a few things that bugged me or looked a bit off. This PR updates the styling for the sidebar headers, the sidebar & content window spacing, and footer spacing.

Before:
<img width="1551" height="785" alt="image" src="https://github.com/user-attachments/assets/20415a3e-037d-4bdd-a28f-78aea1255292" />

After:
<img width="1929" height="795" alt="image" src="https://github.com/user-attachments/assets/b1f15e88-8db0-4d05-ac51-dcd72ef8430f" />
