### PR TITLE
Add authentication display to HTTP proxy list

### DIFF
--- a/src/web/components/httprp.html
+++ b/src/web/components/httprp.html
@@ -232,9 +232,6 @@
                     <a class="item hrpedit_menu_item" cfgpage="vdirs">
                         <i class="angle folder icon"></i> <span class="editorSideMenuText">Virtual Directory</span>
                     </a>
-                    <a class="item hrpedit_menu_item" cfgpage="vdirs">
-                        <i class="angle folder icon"></i> <span class="editorSideMenuText">Virtual Directory</span>
-                    </a>
                     <a class="item hrpedit_menu_item" cfgpage="alias">
                         <i class="at icon"></i> <span class="editorSideMenuText">Alias</span>
                     </a>


### PR DESCRIPTION
This pull request enhances the HTTP Proxy management UI by adding authentication visibility and improving menu consistency. The most important changes are:

**Authentication display in HTTP Proxy table:**

* Added a new "Authentication" column to the HTTP Proxy list table, showing the authentication method for each proxy entry with an icon and label (Basic Auth, Forward Auth, OAuth2, or None). This helps users quickly see which authentication is configured for each proxy. 