### PR TITLE
Add Uptime Monitor checkbox to new rule page.

### DIFF
--- a/src/reverseproxy.go
+++ b/src/reverseproxy.go
@@ -291,6 +291,12 @@ func ReverseProxyHandleAddEndpoint(w http.ResponseWriter, r *http.Request) {
 	}
 	bypassWebsocketOriginCheck := (strbpwsorg == "true")
 
+	//Disable uptime monitor
+	disableUptimeMonitor, err := utils.PostBool(r, "dutm")
+	if err != nil {
+		disableUptimeMonitor = false
+	}
+
 	//Prase the basic auth to correct structure
 	cred, _ := utils.PostPara(r, "cred")
 	basicAuthCredentials := []*dynamicproxy.BasicAuthCredentials{}
@@ -409,6 +415,9 @@ func ReverseProxyHandleAddEndpoint(w http.ResponseWriter, r *http.Request) {
 			// Rate Limit
 			RequireRateLimit: requireRateLimit,
 			RateLimit:        int64(proxyRateLimit),
+
+			// Uptime Monitor
+			DisableUptimeMonitor: disableUptimeMonitor,
 
 			Tags: tags,
 		}

--- a/src/web/components/rules.html
+++ b/src/web/components/rules.html
@@ -49,6 +49,7 @@
                             <label>Proxy Target require TLS Connection <br><small>(i.e. Your proxy target starts with https://)</small></label>
                         </div>
                     </div>
+
                     <!-- Advance configs -->
                     <div class="ui basic segment advanceoptions">
                         <div id="advanceProxyRules" class="ui fluid accordion">
@@ -58,11 +59,22 @@
                             </div>
                             <div class="content">
                                 <div class="field">
-                                    <div class="ui checkbox">
-                                        <input type="checkbox" id="useStickySessionLB">
-                                        <label>Sticky Session<br><small>Enable stick session on upstream load balancing</small></label>
+                                    <div class="ui two column grid">
+                                        <div class="column">
+                                            <div class="ui checkbox">
+                                                <input type="checkbox" id="useStickySessionLB">
+                                                <label>Sticky Session<br><small>Enable stick session on upstream load balancing</small></label>
+                                            </div>
+                                        </div>
+                                        <div class="column">
+                                            <div class="ui checkbox">
+                                                <input type="checkbox" id="uptimeMonitor" checked>
+                                                <label>Uptime Monitor<br><small>Enable active uptime monitor for this proxy endpoint</small></label>
+                                            </div>
+                                        </div>
                                     </div>
                                 </div>
+
                                 <div class="field">
                                     <label>Tags</label>
                                     <input type="text" id="proxyTags" placeholder="e.g. mediaserver, management">
@@ -204,6 +216,7 @@
         let accessRuleToUse = $("#newProxyRuleAccessFilter").val();
         let useStickySessionLB = $("#useStickySessionLB")[0].checked; 
         let tags = $("#proxyTags").val().trim();
+        let uptimeMonitor = $("#uptimeMonitor")[0].checked;
 
         if (rootname.trim() == ""){
             $("#rootname").parent().addClass("error");
@@ -238,6 +251,7 @@
                 access: accessRuleToUse,
                 stickysess: useStickySessionLB,
                 tags: tags,
+                dutm: !uptimeMonitor,
             },
             success: function(data){
                 if (data.error != undefined){


### PR DESCRIPTION
I used the edit function and the implementation in http rules page as guide to copy it to the add function. It adds the option beside the Sticky session checkbox.