### PR TITLE
Typo in plugins.html

### DIFF
--- a/src/web/components/plugins.html
+++ b/src/web/components/plugins.html
@@ -178,7 +178,7 @@
           <tr>
             <th>Plugin Name</th>
             <th>Descriptions</th>
-            <th>Catergory</th>
+            <th>Category</th>
             <th>Action</th>
         </tr></thead>
         <tbody id="pluginTable">


### PR DESCRIPTION
Just a simple typo fix that I noticed while browsing the interface this morning.