### PR TITLE
Optimize Github Action for creating the Docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -47,7 +47,6 @@ jobs:
           else
             echo "docker=${{ env.DOCKER_ACCOUNT }}/${{ env.DOCKER_REPO }}:latest, ${{ env.DOCKER_ACCOUNT }}/${{ env.DOCKER_REPO }}:${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
           fi
-          cache-to: type=registry,ref=${{ env.DOCKER_ACCOUNT }}/${{ env.DOCKER_REPO }}:${{ env.DOCKER_REPO_TAG_CACHE_NAME }},mode=max
 
       - name: Build and push Docker image
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83  # v6.18.0


### PR DESCRIPTION
This pull request enhances the Github Action "Build and push Docker image". The most important changes are:
- Sec: The permissions section has been added ([Link](https://docs.github.com/en/actions/reference/security/secure-use#use-secrets-for-sensitive-information)).
- Enc: The caching method has been switched from gha to registry cache. Reduce the build time of new versions approximately 55 minutes.
- Sec: Pin actions to a full-length commit SHA ([Link](https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions)).
- Enc: The file schema was checked and corrected using yamllint.
- Enc:The tag detection for the Docker image has been revised.
- Enc: Static values ​​outsourced to ENV variable.