### PR TITLE
UPDATE_GEOIP should only update if true

### DIFF
--- a/docker/entrypoint.py
+++ b/docker/entrypoint.py
@@ -100,7 +100,6 @@ def start_zoraxy():
     f"-plugin={ getenv('PLUGIN', '/opt/zoraxy/plugin/') }",
     f"-port=:{ getenv('PORT', '8000') }",
     f"-sshlb={ getenv('SSHLB', 'false') }",
-    f"-update_geoip={ getenv('UPDATE_GEOIP', 'false') }",
     f"-version={ getenv('VERSION', 'false') }",
     f"-webfm={ getenv('WEBFM', 'true') }",
     f"-webroot={ getenv('WEBROOT', './www') }",
@@ -115,8 +114,9 @@ def main():
   print("Updating CA certificates...")
   run(["update-ca-certificates"])
 
-  print("Updating GeoIP data...")
-  run(["zoraxy", "-update_geoip=true"])
+  if getenv("UPDATE_GEOIP", "false").lower() == "true":
+    print("Updating GeoIP data...")
+    run(["zoraxy", "-update_geoip=true"])
 
   os.chdir("/opt/zoraxy/config/")
 


### PR DESCRIPTION
Passing "UPDATE_GEOIP" to the executable in docker seems like a pretty weird idea, as that leads to updating the update again and exiting.
I assume the intended use for this was, to only run "update_geoip" if it is set (in the main function) and simply omit it in the run function.

If this was indeed not the intended use (i.e. allowing for 2 calls of `zoraxy -update_geoip=true` during the entrypoint.py) then please let me know.

Thanks