### PR TITLE
[docs] Fix typo in SniffResult constant

### DIFF
--- a/docs/plugins/docs/3. Basic Examples/4. Dynamic Capture Example.md
+++ b/docs/plugins/docs/3. Basic Examples/4. Dynamic Capture Example.md
@@ -60,7 +60,7 @@ pathRouter.SetDebugPrintMode(true)
 pathRouter.RegisterDynamicSniffHandler("/d_sniff", http.DefaultServeMux, func(dsfr *plugin.DynamicSniffForwardRequest) plugin.SniffResult {
     if strings.HasPrefix(dsfr.RequestURI, "/foobar") {
         fmt.Println("Accepting request with UUID: " + dsfr.GetRequestUUID())
-        return plugin.SniffResultAccpet
+        return plugin.SniffResultAccept
     }
     fmt.Println("Skipping request with UUID: " + dsfr.GetRequestUUID())
     return plugin.SniffResultSkip


### PR DESCRIPTION
Just a quick typo in the docs. (not sure we should mention to also include "strings"? but this is a plugin doc, not a go beginners tutorial)