### PR TITLE
Error message & ":<port>" parsing

### DIFF
--- a/src/start.go
+++ b/src/start.go
@@ -363,7 +363,7 @@ func startupSequence() {
 	if err == nil && ZoraxyAddrPort.IsValid() && ZoraxyAddrPort.Port() > 0 {
 		ZoraxyPort = int(ZoraxyAddrPort.Port())
 	} else {
-		SystemWideLogger.PrintAndLog("plugin-manager", fmt.Sprintf("Could not set port for plugin communication (webUI/-port); fallback to default port '%d' ", ZoraxyPort), err)
+		SystemWideLogger.PrintAndLog("plugin-manager", fmt.Sprintf("Could not set port for plugin communication (webUI/-port); fallback to default port '%d'", ZoraxyPort), err)
 	}
 
 	pluginManager = plugins.NewPluginManager(&plugins.ManagerOptions{


### PR DESCRIPTION
Fixes #946 - Please advice if you want to centralize the WebUIPort splitting somewhere, else this is the "quick and dirty solution to `-port=:1234`".

Tested against: 
* "0.0.0.0:1234"
`(no output)`
* ":1234"
`(no output)`
* ":88443" (invalid port)
`[2025-12-26 15:43:30.998134] [plugin-manager] [system:error] Could not set port for plugin communication (webUI/-port); fallback to default port '8000' : invalid port "88443" parsing "0.0.0.0:88443"`

On a related note: the :88443 (invalid port, too high) is getting passed to `listen` / `Http.ListenAndServe` in the `main.go` - this should probably also be checked in `utils.ValidateListeningAddress` to fail gracefully!