### PR TITLE
fix: error checking origin to avoid goroutine panic

### DIFF
--- a/src/upstreams.go
+++ b/src/upstreams.go
@@ -236,6 +236,11 @@ func ReverseProxyUpstreamSetPriority(w http.ResponseWriter, r *http.Request) {
 	originIP = strings.TrimSpace(originIP)
 
 	editingUpstream, err := targetEndpoint.GetUpstreamOriginByMatchingIP(originIP)
+	if err != nil {
+		SystemWideLogger.PrintAndLog("INFO", "Unable to update upstream weight", err)
+		utils.SendErrorResponse(w, "Failed to update upstream weight! (wrong origin?)")
+		return
+	}
 	editingUpstream.Weight = weight
 	// The editing upstream is a pointer to the runtime object
 	// and the change of weight do not requre a respawn of the proxy object


### PR DESCRIPTION
currently when updating a weight and providing an invalid "origin", the entire application panics.

How to reproduce?
- Start ./zoraxy
- Create new proxy rule, call it `boop.local`, point it to `beep.local`
- Try to use the API to update weight (making it a fallback), but screw up the "origin" (i.e. forget the port, add the port, mistype, ...)
`http://localhost:8000/api/proxy/upstream/setPriority?ep=boop.local&origin=beep.local:1234&weight=0`
- panic, see below.

```
2025/12/26 18:18:25 http: panic serving 127.0.0.1:52528: runtime error: invalid memory address or nil pointer dereference
goroutine 128 [running]:
net/http.(*conn).serve.func1()
        /root/go/src/net/http/server.go:1943 +0xd3
panic({0x1f99f00?, 0x6033820?})
        /root/go/src/runtime/panic.go:783 +0x132
main.ReverseProxyUpstreamSetPriority({0x3d7a498, 0xc00487eff0}, 0xc0002a5900)
        /root/zoraxy/src/upstreams.go:239 +0x2aa
imuslab.com/zoraxy/mod/auth.(*RouterDef).HandleFunc.func2({0x3d7a498?, 0xc00487eff0?}, 0x1e7c0a0?)
        /root/zoraxy/src/mod/auth/router.go:58 +0x5c
net/http.HandlerFunc.ServeHTTP(0xc0000ec540?, {0x3d7a498?, 0xc00487eff0?}, 0x0?)
        /root/go/src/net/http/server.go:2322 +0x29
net/http.(*ServeMux).ServeHTTP(0x0?, {0x3d7a498, 0xc00487eff0}, 0xc0002a5900)
        /root/go/src/net/http/server.go:2861 +0x1c7
github.com/gorilla/csrf.(*csrf).ServeHTTP(0xc004876a80, {0x3d7a498, 0xc00487eff0}, 0xc0002a5400)
        /root/go/pkg/mod/github.com/gorilla/csrf@v1.7.2/csrf.go:306 +0x5cc
net/http.(*ServeMux).ServeHTTP(0x47d5f9?, {0x3d7a498, 0xc00487eff0}, 0xc0002a5400)
        /root/go/src/net/http/server.go:2861 +0x1c7
net/http.serverHandler.ServeHTTP({0xc0001d8200?}, {0x3d7a498?, 0xc00487eff0?}, 0x6?)
        /root/go/src/net/http/server.go:3340 +0x8e
net/http.(*conn).serve(0xc00491ce10, {0x3d7ccf8, 0xc004882a20})
        /root/go/src/net/http/server.go:2109 +0x665
created by net/http.(*Server).Serve in goroutine 1
        /root/go/src/net/http/server.go:3493 +0x485
```

Reason for this is a missing sanity check, the `err` was never evaluated after retrieving the GetUpstreamOriginByMatchingIP.
This at least checks the error message.