### PR TITLE
fix: forward auth saving and defaults

### DIFF
--- a/src/mod/auth/sso/forward/forward.go
+++ b/src/mod/auth/sso/forward/forward.go
@@ -140,11 +140,11 @@ func (ar *AuthRouter) handleOptionsPOST(w http.ResponseWriter, r *http.Request) 
 
 	// Write changes to runtime
 	ar.options.Address = address
-	ar.options.ResponseHeaders = strings.Split(responseHeaders, ",")
-	ar.options.ResponseClientHeaders = strings.Split(responseClientHeaders, ",")
-	ar.options.RequestHeaders = strings.Split(requestHeaders, ",")
-	ar.options.RequestIncludedCookies = strings.Split(requestIncludedCookies, ",")
-	ar.options.RequestExcludedCookies = strings.Split(requestExcludedCookies, ",")
+	ar.options.ResponseHeaders = cleanSplit(responseHeaders)
+	ar.options.ResponseClientHeaders = cleanSplit(responseClientHeaders)
+	ar.options.RequestHeaders = cleanSplit(requestHeaders)
+	ar.options.RequestIncludedCookies = cleanSplit(requestIncludedCookies)
+	ar.options.RequestExcludedCookies = cleanSplit(requestExcludedCookies)
 	ar.options.RequestIncludeBody, _ = strconv.ParseBool(requestIncludeBody)
 	ar.options.UseXOriginalHeaders, _ = strconv.ParseBool(useXOriginalHeaders)
 


### PR DESCRIPTION
Hi,

As noted here: #895 a PR was prefered, I saw noone has yet created a PR so I created this PR.

This adresses an issue, where ReponseHeaders were being written to the client instead of the server.

This should also adress an issue, where `strings.Split` was used instead of `cleanSplit`, which caused empty fields to be stored as `[""]` instead of `nil`, breaking the "copy all if empty" default behavior after saving settings.
The same is applied already above on line 72 to 76 for example: https://github.com/CrazyWolf13/zoraxy/blob/3fd7474a16eb4e3a66b242ee3905a8f58df29893/src/mod/auth/sso/forward/forward.go#L72-L76