### PR TITLE
Fix certificate file permissions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -50,7 +50,7 @@ jobs:
           fi
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294  # v7.0.0
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
         with:
           context: ./docker
           push: true

--- a/src/acme.go
+++ b/src/acme.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"math/rand"
 	"net/http"
+	"os"
 	"regexp"
 	"strconv"
 	"time"
@@ -38,7 +39,20 @@ func initACME() *acme.ACMEHandler {
 		port = getRandomPort(30000)
 	}
 
-	return acme.NewACME(strconv.Itoa(port), sysdb, SystemWideLogger, *acmeTestMode)
+	keyFileMode := parseACMEFileMode(*acmeKeyFileMode, 0600, "acmekeymode")
+	publicFileMode := parseACMEFileMode(*acmePublicFileMode, 0644, "acmepublicmode")
+
+	return acme.NewACME(strconv.Itoa(port), sysdb, SystemWideLogger, *acmeTestMode, keyFileMode, publicFileMode)
+}
+
+func parseACMEFileMode(raw string, fallback os.FileMode, flagName string) os.FileMode {
+	parsed, err := strconv.ParseUint(raw, 8, 32)
+	if err != nil {
+		SystemWideLogger.Println("Invalid " + flagName + " value " + raw + ", using fallback " + fmt.Sprintf("%#o", fallback))
+		return fallback
+	}
+
+	return os.FileMode(parsed)
 }
 
 // Restart ACME handler and auto renewer

--- a/src/def.go
+++ b/src/def.go
@@ -79,6 +79,8 @@ var (
 	acmeAutoRenewInterval = flag.Int("autorenew", 86400, "ACME auto TLS/SSL certificate renew check interval (seconds)")
 	acmeCertAutoRenewDays = flag.Int("earlyrenew", 30, "Number of days to early renew a soon expiring certificate (days)")
 	acmeTestMode          = flag.Bool("acmetestmode", false, "Run ACME in test/staging mode")
+	acmeKeyFileMode       = flag.String("acmekeymode", "0600", "File mode for ACME private key files (octal)")
+	acmePublicFileMode    = flag.String("acmepublicmode", "0644", "File mode for ACME certificate and metadata files (octal)")
 
 	/* Logging Configuration Flags */
 	enableLog = flag.Bool("enablelog", true, "Enable system wide logging, set to false for writing log to STDOUT only")

--- a/src/mod/acme/acme.go
+++ b/src/mod/acme/acme.go
@@ -76,21 +76,25 @@ func (u *ACMEUser) GetPrivateKey() crypto.PrivateKey {
 
 // ACMEHandler handles ACME-related operations.
 type ACMEHandler struct {
-	Port              string
-	Database          *database.Database
-	Logger            *logger.Logger
-	TestMode          bool
+	Port           string
+	Database       *database.Database
+	Logger         *logger.Logger
+	TestMode       bool
+	KeyFileMode    os.FileMode
+	PublicFileMode os.FileMode
 }
 
 // NewACME creates a new ACMEHandler instance.
 func NewACME(
-			port string, database *database.Database,
-			logger *logger.Logger, testMode bool) *ACMEHandler {
+	port string, database *database.Database,
+	logger *logger.Logger, testMode bool, keyFileMode os.FileMode, publicFileMode os.FileMode) *ACMEHandler {
 	return &ACMEHandler{
-		Port:              port,
-		Database:          database,
-		Logger:            logger,
-		TestMode:          testMode,
+		Port:           port,
+		Database:       database,
+		Logger:         logger,
+		TestMode:       testMode,
+		KeyFileMode:    keyFileMode,
+		PublicFileMode: publicFileMode,
 	}
 }
 
@@ -103,6 +107,15 @@ func (a *ACMEHandler) Logf(message string, err error) {
 // Function defined for future compatibility
 func (a *ACMEHandler) Close() error {
 	return nil
+}
+
+func (a *ACMEHandler) writeFileWithMode(filename string, data []byte, mode os.FileMode) error {
+	err := os.WriteFile(filename, data, mode)
+	if err != nil {
+		return err
+	}
+
+	return os.Chmod(filename, mode)
 }
 
 // ObtainCert obtains a certificate for the specified domains.
@@ -164,7 +177,7 @@ func (a *ACMEHandler) ObtainCert(domains []string, certificateName string, email
 		} else {
 			// wrong caName => use default acme
 			config.CADirURL, _ = loadCAApiServerFromName("Let's Encrypt", a.TestMode)
-			a.Logf("Using Default ACME " + config.CADirURL + " for CA Directory URL", nil)
+			a.Logf("Using Default ACME "+config.CADirURL+" for CA Directory URL", nil)
 		}
 	}
 
@@ -314,12 +327,12 @@ func (a *ACMEHandler) ObtainCert(domains []string, certificateName string, email
 
 	// Each certificate comes back with the cert bytes, the bytes of the client's
 	// private key, and a certificate URL.
-	err = os.WriteFile("./conf/certs/"+certificateName+".pem", certificates.Certificate, 0777)
+	err = a.writeFileWithMode("./conf/certs/"+certificateName+".pem", certificates.Certificate, a.PublicFileMode)
 	if err != nil {
 		a.Logf("Failed to write public key to disk", err)
 		return false, err
 	}
-	err = os.WriteFile("./conf/certs/"+certificateName+".key", certificates.PrivateKey, 0777)
+	err = a.writeFileWithMode("./conf/certs/"+certificateName+".key", certificates.PrivateKey, a.KeyFileMode)
 	if err != nil {
 		a.Logf("Failed to write private key to disk", err)
 		return false, err
@@ -341,7 +354,7 @@ func (a *ACMEHandler) ObtainCert(domains []string, certificateName string, email
 		return false, err
 	}
 
-	err = os.WriteFile("./conf/certs/"+certificateName+".json", certInfoBytes, 0777)
+	err = a.writeFileWithMode("./conf/certs/"+certificateName+".json", certInfoBytes, a.PublicFileMode)
 	if err != nil {
 		a.Logf("Failed to write certificate renew config to file", err)
 		return false, err

--- a/src/mod/tlscert/certgen.go
+++ b/src/mod/tlscert/certgen.go
@@ -59,13 +59,7 @@ func (m *Manager) GenerateSelfSignedCertificate(cn string, sans []string, certFi
 	}
 
 	// Write certificate to file
-	certOut, err := os.Create(filepath.Join(m.CertStore, certFile))
-	if err != nil {
-		m.Logger.PrintAndLog("tls-router", "Failed to open cert file for writing: "+certFile, err)
-		return err
-	}
-	defer certOut.Close()
-	err = pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	err = writeFileWithMode(certPath, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER}), defaultPublicCertFileMode)
 	if err != nil {
 		m.Logger.PrintAndLog("tls-router", "Failed to write certificate to file: "+certFile, err)
 		return err
@@ -77,13 +71,7 @@ func (m *Manager) GenerateSelfSignedCertificate(cn string, sans []string, certFi
 		m.Logger.PrintAndLog("tls-router", "Unable to marshal ECDSA private key", err)
 		return err
 	}
-	keyOut, err := os.Create(filepath.Join(m.CertStore, keyFile))
-	if err != nil {
-		m.Logger.PrintAndLog("tls-router", "Failed to open key file for writing: "+keyFile, err)
-		return err
-	}
-	defer keyOut.Close()
-	err = pem.Encode(keyOut, &pem.Block{Type: "EC PRIVATE KEY", Bytes: privBytes})
+	err = writeFileWithMode(keyPath, pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: privBytes}), defaultPrivateKeyFileMode)
 	if err != nil {
 		m.Logger.PrintAndLog("tls-router", "Failed to write private key to file: "+keyFile, err)
 		return err

--- a/src/mod/tlscert/handler.go
+++ b/src/mod/tlscert/handler.go
@@ -189,20 +189,12 @@ func (m *Manager) HandleCertUpload(w http.ResponseWriter, r *http.Request) {
 	}
 
 	os.MkdirAll(m.CertStore, 0775)
-	f, err := os.Create(filepath.Join(m.CertStore, overWriteFilename))
-	if err != nil {
-		http.Error(w, "Failed to create file", http.StatusInternalServerError)
-		return
+	fileMode := defaultPublicCertFileMode
+	if keytype == "pri" {
+		fileMode = defaultPrivateKeyFileMode
 	}
-	defer f.Close()
 
-	// copy file contents to destination file
-	_, err = io.Copy(f, file)
-	if err != nil {
-		http.Error(w, "Failed to save file", http.StatusInternalServerError)
-		return
-	}
-	_, err = f.Write(fileBytes)
+	err = writeFileWithMode(filepath.Join(m.CertStore, overWriteFilename), fileBytes, fileMode)
 	if err != nil {
 		http.Error(w, "Failed to save file", http.StatusInternalServerError)
 		return

--- a/src/mod/tlscert/tlscert.go
+++ b/src/mod/tlscert/tlscert.go
@@ -39,6 +39,20 @@ type Manager struct {
 //go:embed localhost.pem localhost.key
 var buildinCertStore embed.FS
 
+const (
+	defaultPublicCertFileMode os.FileMode = 0644
+	defaultPrivateKeyFileMode os.FileMode = 0600
+)
+
+func writeFileWithMode(filename string, data []byte, mode os.FileMode) error {
+	err := os.WriteFile(filename, data, mode)
+	if err != nil {
+		return err
+	}
+
+	return os.Chmod(filename, mode)
+}
+
 func NewManager(certStore string, logger *logger.Logger) (*Manager, error) {
 	if !utils.FileExists(certStore) {
 		os.MkdirAll(certStore, 0775)
@@ -50,12 +64,12 @@ func NewManager(certStore string, logger *logger.Logger) (*Manager, error) {
 	//Check if this is initial setup
 	if !utils.FileExists(pubKey) {
 		buildInPubKey, _ := buildinCertStore.ReadFile(filepath.Base(pubKey))
-		os.WriteFile(pubKey, buildInPubKey, 0775)
+		writeFileWithMode(pubKey, buildInPubKey, defaultPublicCertFileMode)
 	}
 
 	if !utils.FileExists(priKey) {
 		buildInPriKey, _ := buildinCertStore.ReadFile(filepath.Base(priKey))
-		os.WriteFile(priKey, buildInPriKey, 0775)
+		writeFileWithMode(priKey, buildInPriKey, defaultPrivateKeyFileMode)
 	}
 
 	thisManager := Manager{


### PR DESCRIPTION
Fixes #1115

- add separate file modes for private key files and public certificate or metadata files
- enforce secure file modes when ACME renewals overwrite existing cert, key, and json files
- apply private and public file permissions to uploaded, bundled localhost, and self-signed certificate files
