### PR TITLE
fix: Allow Location header rewrite when target matches OriginalHost

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -50,7 +50,7 @@ jobs:
           fi
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294  # v7.0.0
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
         with:
           context: ./docker
           push: true

--- a/src/mod/dynamicproxy/dpcore/utils.go
+++ b/src/mod/dynamicproxy/dpcore/utils.go
@@ -31,7 +31,7 @@ func replaceLocationHost(urlString string, rrr *ResponseRewriteRuleSet, useTLS b
 	//like news.example.com.
 	// The later check bypass apache screw up method of redirection header
 	// e.g. https://imuslab.com -> http://imuslab.com:443
-	if rrr.ProxyDomain != u.Host && !strings.Contains(u.Host, rrr.OriginalHost+":") {
+	if rrr.ProxyDomain != u.Host && u.Host != rrr.OriginalHost && !strings.Contains(u.Host, rrr.OriginalHost+":") {
 		//New location domain not matching proxy target domain.
 		//Do not modify location header
 		return urlString, nil


### PR DESCRIPTION
## Fix: Allow Location header rewrite when target matches OriginalHost

### Problem

When a backend application behind a reverse proxy (Zoraxy) generates redirect responses using the forwarded `Host` header (the public domain), Zoraxy fails to rewrite the `Location` header scheme from `http://` to `https://` when needed.

### Symptoms

DAV clients (CalDAV/CardDAV) connecting to an HTTPS-protected endpoint fail with:
```
Received redirect from HTTPS to HTTP
```

The client logs show a sequence of redirects, all incorrectly using `http://` despite the client connecting over HTTPS:
```
Checking user-given URL: https://publicdomain.com/dav.php
--> PROPFIND https://publicdomain.com/dav.php
<-- 308 https://publicdomain.com/.well-known/carddav
Location: http://publicdomain.com/dav.php  ← Wrong scheme!
EXCEPTION: Received redirect from HTTPS to HTTP
```

### Root Cause

In `src/mod/dynamicproxy/dpcore/utils.go`, the `replaceLocationHost` function checks if a Location header should be rewritten:

```go
if rrr.ProxyDomain != u.Host && !strings.Contains(u.Host, rrr.OriginalHost+":") {
    return urlString, nil  // Skip rewrite
}
```

This condition is designed to avoid rewriting redirects to unrelated domains. However, it incorrectly skips rewriting when:
- `rrr.ProxyDomain` = backend IP (e.g., `192.168.1.100:80`)
- `u.Host` = public domain (e.g., `publicdomain.com`)
- `rrr.OriginalHost` = public domain (e.g., `publicdomain.com`)

The Location header points to the public domain (which is correct for the client), but the condition doesn't recognize this and skips the scheme rewrite.

### Solution

Add an explicit check for `u.Host == rrr.OriginalHost`:

```go
if rrr.ProxyDomain != u.Host && u.Host != rrr.OriginalHost && !strings.Contains(u.Host, rrr.OriginalHost+":") {
    return urlString, nil
}
```

Now redirects to the public domain are properly rewritten.

### Example Scenario

**Setup:**
- Public domain: `publicdomain.com`
- Backend: `192.168.1.100:80` (HTTP only)
- Client connects via: `https://publicdomain.com/dav.php`

**Before fix:**
- Backend generates: `Location: http://publicdomain.com/dav.php`
- Zoraxy sees: `u.Host` = `publicdomain.com`, `rrr.ProxyDomain` = `192.168.1.100:80`
- Condition fails to match (not equal to ProxyDomain)
- Rewrite is skipped → Client gets `http://` URL
- Client rejects downgrade from HTTPS to HTTP ❌

**After fix:**
- Zoraxy sees: `u.Host` = `publicdomain.com`, `rrr.OriginalHost` = `publicdomain.com`
- Condition now matches (u.Host == rrr.OriginalHost)
- Scheme is rewritten to `https://`
- Client gets correct `https://` URL ✅

### Common Backends Affected

This bug affects any backend that uses HTTP_HOST to generate absolute URLs:
- Apache with RewriteRule redirects
- PHP applications (Laravel, Symfony, etc.)
- Node.js apps using req.hostname
- Other frameworks that honor the Host header

### Testing

Tested with:
- Baikal CalDAV/CardDAV server
- Apache with mod_rewrite
- DAVx5 client on Android
- Cloudflare + Zoraxy TLS termination setup

The one-line fix resolves the issue without breaking existing behavior.
