### PR TITLE
fix(streamproxy): re-init atomic counters when loading rules (#1157)

### DIFF
--- a/src/mod/streamproxy/streamproxy.go
+++ b/src/mod/streamproxy/streamproxy.go
@@ -125,6 +125,14 @@ func NewStreamProxy(options *Options) (*Manager, error) {
 			continue
 		}
 
+		//Re-initialize unexported runtime fields. These are skipped by json
+		//(un)marshal and would otherwise be nil for resumed rules, causing a
+		//SIGSEGV in connCopy on the first forwarded byte (issue #1157).
+		aAcc := atomic.Int64{}
+		bAcc := atomic.Int64{}
+		thisRelayConfig.aTobAccumulatedByteTransfer = &aAcc
+		thisRelayConfig.bToaAccumulatedByteTransfer = &bAcc
+
 		//Append the config to the list
 		previousRules = append(previousRules, thisRelayConfig)
 	}


### PR DESCRIPTION
Resumed stream-proxy rules panic in `connCopy` (`tcpprox.go:41`) on the first forwarded byte because their `*atomic.Int64` accumulators are nil after JSON load — the fields are unexported and so are skipped by json (un)marshal, while `NewConfig` initialises them on the create path only.

Allocate fresh `atomic.Int64` values for both counters right after `json.Unmarshal` succeeds, mirroring the create path. Fixes #1157.