### PR TITLE
Add OpenBSD build support

### DIFF
--- a/src/mod/sshprox/sshprox_openbsd.go
+++ b/src/mod/sshprox/sshprox_openbsd.go
@@ -1,0 +1,10 @@
+//go:build openbsd
+
+package sshprox
+
+import "embed"
+
+const UseWinTTY = false
+
+//go:embed gotty/*
+var gotty embed.FS


### PR DESCRIPTION
Building Zoraxy on OpenBSD 7.8 (amd64) fails because the sshprox package uses symbols UseWinTTY and gotty that are only defined in files with build tags that exclude OpenBSD.

The error is:
  mod/sshprox/sshprox.go:67:5: undefined: UseWinTTY
  mod/sshprox/sshprox.go:109:5: undefined: UseWinTTY
  mod/sshprox/sshprox.go:148:20: undefined: gotty 
  mod/sshprox/sshprox.go:155:22: undefined: gotty
  mod/sshprox/sshprox.go:209:5: undefined: UseWinTTY
  mod/sshprox/utils.go:24:5: undefined: UseWinTTY
  mod/sshprox/utils.go:36:12: undefined: gotty

I add a single file, src/mod/sshprox/sshprox_openbsd.go, with the build constraint //go:build openbsd. It defines `UseWinTTY = false` and provides an embedded filesystem for the gotty directory. No existing files are modified.

After the change the package compiles and the binary links on OpenBSD. The gotty executable for OpenBSD is not embedded, so the SSH proxy feature will still return "platform not supported" at runtime. This PR only addresses the build breakage.