### PR TITLE
Add custom URI for Uptime Monitor health check

### DIFF
--- a/src/mod/dynamicproxy/typedef.go
+++ b/src/mod/dynamicproxy/typedef.go
@@ -248,10 +248,11 @@ type ProxyEndpoint struct {
 	CaptchaConfig  *CaptchaConfig // CAPTCHA provider configuration
 
 	//Uptime Monitor
-	DisableUptimeMonitor       bool //Disable uptime monitor for this endpoint
-	DisableAutoFallback        bool //Disable automatic fallback when uptime monitor detects an upstream is down (continue monitoring but don't auto-disable upstream)
-	DisableLogging             bool //Disable logging of reverse proxy requests
-	DisableStatisticCollection bool //Disable statistic collection for this endpoint
+	DisableUptimeMonitor       bool   //Disable uptime monitor for this endpoint
+	UptimeMonitorURI           string //Optional URI path used by the uptime monitor health check (e.g. "/identity", "/healthz"). Empty = default "/"
+	DisableAutoFallback        bool   //Disable automatic fallback when uptime monitor detects an upstream is down (continue monitoring but don't auto-disable upstream)
+	DisableLogging             bool   //Disable logging of reverse proxy requests
+	DisableStatisticCollection bool   //Disable statistic collection for this endpoint
 
 	//Exploit Detection
 	BlockCommonExploits bool //Enable blocking of common exploits (SQLi, XSS, etc.)

--- a/src/mod/uptime/typedef.go
+++ b/src/mod/uptime/typedef.go
@@ -8,7 +8,7 @@ import (
 
 const (
 	LOG_MODULE_NAME           = "uptime-monitor"
-	UPTIME_MONITOR_USER_AGENT = "zoraxy-uptime/1.3"
+	UPTIME_MONITOR_USER_AGENT = "zoraxy-uptime/1.4"
 )
 
 type Record struct {
@@ -36,6 +36,7 @@ type Target struct {
 	Protocol          string
 	ProxyType         ProxyType
 	SkipTlsValidation bool
+	HealthCheckURI    string //Optional URI path appended to URL for the health check. If empty, "/" is used.
 }
 
 type Config struct {

--- a/src/mod/uptime/uptime.go
+++ b/src/mod/uptime/uptime.go
@@ -95,7 +95,7 @@ func (m *Monitor) masterPingTargets() {
 
 }
 
-//pingTargets pings a list of targets with a given timeout and whether to log the results in the online status log
+// pingTargets pings a list of targets with a given timeout and whether to log the results in the online status log
 func (m *Monitor) pingTargets(timeout time.Duration, targets []*Target, requireOnlineStatusLog bool) {
 	for _, target := range targets {
 		if target.Protocol != "http" && target.Protocol != "https" {
@@ -113,7 +113,7 @@ func (m *Monitor) pingTargets(timeout time.Duration, targets []*Target, requireO
 				Timestamp:  now,
 				ID:         target.ID,
 				Name:       target.Name,
-				URL:        target.URL,
+				URL:        buildHealthCheckURL(target.URL, target.HealthCheckURI),
 				Protocol:   target.Protocol,
 				Online:     online,
 				StatusCode: statusCode,
@@ -344,7 +344,8 @@ func (m *Monitor) HandleUptimeLogRead(w http.ResponseWriter, r *http.Request) {
 // Get website stauts with latency given URL, return is conn succ and its latency and status code
 func (m *Monitor) getWebsiteStatusWithLatency(target *Target, timeout time.Duration) (bool, int64, int) {
 	start := time.Now().UnixNano() / int64(time.Millisecond)
-	statusCode, err := m.getWebsiteStatus(target.URL, target.SkipTlsValidation, timeout)
+	checkURL := buildHealthCheckURL(target.URL, target.HealthCheckURI)
+	statusCode, err := m.getWebsiteStatus(checkURL, target.SkipTlsValidation, timeout)
 	end := time.Now().UnixNano() / int64(time.Millisecond)
 	if err != nil {
 		if m.Config.Verbal {
@@ -444,4 +445,21 @@ func (m *Monitor) getWebsiteStatus(url string, skipTLSVerification bool, timeout
 	defer resp.Body.Close()
 	status_code := resp.StatusCode
 	return status_code, nil
+}
+
+// buildHealthCheckURL joins a base URL (e.g. "http://host:port") with an
+// optional health-check URI path (e.g. "/identity"). If the URI is empty,
+// the base URL is returned unchanged. The URI is sanitized so users can
+// enter "identity", "/identity" or "/identity?token=foo" indifferently.
+func buildHealthCheckURL(baseURL, uri string) string {
+	uri = strings.TrimSpace(uri)
+	if uri == "" {
+		return baseURL
+	}
+	// Strip trailing slashes from base, ensure leading slash on uri
+	base := strings.TrimRight(baseURL, "/")
+	if !strings.HasPrefix(uri, "/") {
+		uri = "/" + uri
+	}
+	return base + uri
 }

--- a/src/reverseproxy.go
+++ b/src/reverseproxy.go
@@ -332,6 +332,10 @@ func ReverseProxyHandleAddEndpoint(w http.ResponseWriter, r *http.Request) {
 		enableUtm = true
 	}
 
+	// Custom URI used by the uptime monitor health check (optional)
+	utmURI, _ := utils.PostPara(r, "utmURI")
+	utmURI = strings.TrimSpace(utmURI)
+
 	// Disable logging?
 	disableLog, _ := utils.PostBool(r, "disableLog")
 
@@ -536,6 +540,7 @@ func ReverseProxyHandleAddEndpoint(w http.ResponseWriter, r *http.Request) {
 
 			Tags:                 tags,
 			DisableUptimeMonitor: !enableUtm,
+			UptimeMonitorURI:     utmURI,
 			DisableAutoFallback:  false, // Default to false for new endpoints
 			DisableLogging:       disableLog,
 			BlockCommonExploits:  blockCommonExploits,
@@ -662,6 +667,10 @@ func ReverseProxyHandleEditEndpoint(w http.ResponseWriter, r *http.Request) {
 		disbleUtm = false
 	}
 
+	// Custom URI used by the uptime monitor health check (optional)
+	utmURI, _ := utils.PostPara(r, "utmURI")
+	utmURI = strings.TrimSpace(utmURI)
+
 	// Auth Provider
 	authProviderTypeStr, _ := utils.PostPara(r, "authprovider")
 	if authProviderTypeStr == "" {
@@ -782,6 +791,7 @@ func ReverseProxyHandleEditEndpoint(w http.ResponseWriter, r *http.Request) {
 	newProxyEndpoint.CaptchaConfig = captchaConfig
 	newProxyEndpoint.UseStickySession = useStickySession
 	newProxyEndpoint.DisableUptimeMonitor = disbleUtm
+	newProxyEndpoint.UptimeMonitorURI = utmURI
 	newProxyEndpoint.DisableAutoFallback = disableAutoFallback
 	newProxyEndpoint.DisableChunkedTransferEncoding = disableChunkedEncoding
 	newProxyEndpoint.ForceHTTP11 = forceHTTP11

--- a/src/web/components/httprp.html
+++ b/src/web/components/httprp.html
@@ -361,6 +361,13 @@
                                     <small>Enable active uptime monitor and auto disable upstreams that are offline</small></label>
                             </div>
                             <br>
+                            <b>Health-check URI <span style="opacity:0.6; font-weight:normal;">(optional)</span></b>
+                            <div class="ui small fluid input" style="margin-top: 0.4em;">
+                                <input type="text" class="UptimeMonitorURI" placeholder="/" autocomplete="off">
+                            </div>
+                            <small style="opacity:0.7;">Path appended to the upstream URL when the uptime monitor performs its check (e.g. <code>/identity</code> for Plex, <code>/healthz</code>). Leave empty to use <code>/</code>.</small>
+                            <br><br>
+                            <br>
                             <div class="ui checkbox" style="margin-top: 0.4em;">
                                 <input type="checkbox" class="UseStickySession">
                                 <label>Use Sticky Session<br>
@@ -1127,6 +1134,7 @@
         let epttype = "host";
         let useStickySession =  $(editor).find(".UseStickySession")[0].checked;
         let DisableUptimeMonitor = !$(editor).find(".EnableUptimeMonitor")[0].checked;
+        let uptimeMonitorURI = $(editor).find(".UptimeMonitorURI").val().trim();
         let disableAutoFallback = false; //$(editor).find(".DisableAutoFallback")[0].checked;
         let authProviderType = $(editor).find(".authProviderPicker input[type='radio']:checked").val();
         let requireRateLimit = $(editor).find(".RequireRateLimit")[0].checked;
@@ -1166,6 +1174,7 @@
                 "rootname": uuid,
                 "ss":useStickySession,
                 "dutm": DisableUptimeMonitor,
+                "utmURI": uptimeMonitorURI,
                 "dAutoFallback": disableAutoFallback,
                 "bpgtls": bypassGlobalTLS,
                 "authprovider" :authProviderType,
@@ -1778,9 +1787,17 @@
             // Enable/disable the auto fallback option based on uptime monitor state
             var isUptimeMonitorEnabled = $(this).is(":checked");
             editor.find(".DisableAutoFallback").prop("disabled", !isUptimeMonitorEnabled);
+            editor.find(".UptimeMonitorURI").prop("disabled", !isUptimeMonitorEnabled);
             if (!isUptimeMonitorEnabled) {
                 editor.find(".DisableAutoFallback").prop("checked", false);
             }
+            saveProxyInlineEdit(uuid);
+        });
+
+        editor.find(".UptimeMonitorURI").off("change");
+        editor.find(".UptimeMonitorURI").val(subd.UptimeMonitorURI || "");
+        editor.find(".UptimeMonitorURI").prop("disabled", subd.DisableUptimeMonitor);
+        editor.find(".UptimeMonitorURI").on("change", function() {
             saveProxyInlineEdit(uuid);
         });
 

--- a/src/web/components/rules.html
+++ b/src/web/components/rules.html
@@ -70,6 +70,11 @@
                                         </label>
                                     </div>
                                 </div>
+                                <div class="field">
+                                    <label>Uptime monitor health-check URI <small>(optional)</small></label>
+                                    <input type="text" id="utmURI" placeholder="/" autocomplete="off">
+                                    <small>Path appended to the upstream URL when the uptime monitor performs its check (e.g. <code>/identity</code> for Plex, <code>/healthz</code>). Leave empty to use <code>/</code>.</small>
+                                </div>
 
                                 <div class="field">
                                     <label>Tags</label>
@@ -344,6 +349,7 @@
         let useStickySessionLB = $("#useStickySessionLB")[0].checked; 
         let tags = $("#proxyTags").val().trim();
         let enableUtm = $("#enableUtm")[0].checked;
+        let utmURI = $("#utmURI").val().trim();
         let disableLog = $("#disableLog")[0].checked;
         let disableStatisticCollection = $("#disableStatisticCollection")[0].checked;
         let blockCommonExploits = $("#blockCommonExploits")[0].checked;
@@ -384,6 +390,7 @@
                 stickysess: useStickySessionLB,
                 tags: tags,
                 enableUtm: enableUtm,
+                utmURI: utmURI,
                 disableLog: disableLog,
                 dStatisticCollection: disableStatisticCollection,
                 blockCommonExploits: blockCommonExploits,
@@ -401,6 +408,7 @@
                     $("#rootname").val("");
                     $("#proxyDomain").val("");
                     $("#proxyTags").val("");
+                    $("#utmURI").val("");
                     $("#blockCommonExploits").prop("checked", false);
                     $("#blockAICrawlers").prop("checked", false);
                     $("#mitigationAction").parent().dropdown("set selected", "0");

--- a/src/wrappers.go
+++ b/src/wrappers.go
@@ -192,6 +192,7 @@ func GetUptimeTargetsFromReverseProxyRules(dp *dynamicproxy.Router) []*uptime.Ta
 				Protocol:          protocol,
 				ProxyType:         uptime.ProxyType_Host,
 				SkipTlsValidation: origin.SkipCertValidations,
+				HealthCheckURI:    target.UptimeMonitorURI,
 			})
 
 			//Add each virtual directory into the list
@@ -210,6 +211,7 @@ func GetUptimeTargetsFromReverseProxyRules(dp *dynamicproxy.Router) []*uptime.Ta
 					Protocol:          protocol,
 					ProxyType:         uptime.ProxyType_Vdir,
 					SkipTlsValidation: origin.SkipCertValidations,
+					HealthCheckURI:    target.UptimeMonitorURI,
 				})
 
 			}


### PR DESCRIPTION
Fixes #1050

## Summary

Currently the Uptime Monitor probes upstreams on `/` only. For services that return a non-2xx/3xx status on the root path (Plex returns 401, n8n on `/`, some APIs return 404), the monitor permanently flags them as *"Target online but not accessible"* (orange status).

This PR adds an optional **Health-check URI** field on each proxy host. When set, the uptime monitor appends it to the upstream URL when performing its check, so users can point it at a path that is known to return a healthy status (`/identity` for Plex, `/healthz`, `/api/health`, etc.).

When the field is left empty, behavior is **strictly unchanged** (probes `/` exactly as before).

## Changes

**Backend (Go)**
- `mod/dynamicproxy/typedef.go` — added `UptimeMonitorURI string` to `ProxyEndpoint`
- `mod/uptime/typedef.go` — added `HealthCheckURI string` to `Target`, bumped `UPTIME_MONITOR_USER_AGENT` from `zoraxy-uptime/1.3` to `zoraxy-uptime/1.4`
- `mod/uptime/uptime.go`:
  - new `buildHealthCheckURL()` helper joining base URL + URI, tolerant to leading/trailing slashes
  - `getWebsiteStatusWithLatency()` uses it when pinging
  - `Record.URL` now stores the actual checked URL (with path), so the Uptime Monitor page transparently shows `http://host:port/health` instead of just `http://host:port`
- `wrappers.go` — `GetUptimeTargetsFromReverseProxyRules()` propagates the field for both Origin Server and Virtual Directory targets
- `reverseproxy.go` — parses `utmURI` POST param (trimmed) in both add and edit handlers

**Frontend**
- `web/components/rules.html` — new text input in the New Proxy Rule form (Advanced Settings)
- `web/components/httprp.html` — new text input in the inline editor (Upstream tab), styled with Semantic UI's `ui small fluid input` pattern to match the existing "Connection Timeout" field; auto-disabled when "Monitor Uptime" is unchecked, matching the existing `DisableAutoFallback` UX

## Backward compatibility

No config migration is needed. The new `UptimeMonitorURI` field defaults to `""` (empty) when reading existing v3.3.x config files, which preserves the current `/` probe behavior. Old configs work as-is on the new binary, and new configs work on the old binary (the unknown field is just ignored by Go's `json.Unmarshal`).

Verified end-to-end with `tcpdump`: same Zoraxy instance, two rules — one with `/healthz` set, one with empty URI — produces respectively `GET /healthz` and `GET /` on the wire, both with `User-Agent: zoraxy-uptime/1.4`.

## Testing

- `gofmt` clean on all modified Go files, `go vet ./...` passes
- Manual UX: field is grayed out when monitor is off; accepts `identity`, `/identity`, `/identity?token=x` indifferently; empty value behaves like before
- End-to-end test against a fake upstream returning 401 on `/` and 200 on `/healthz`:
  - empty URI → orange "online but not accessible" status (expected, 401 from `/`)
  - URI = `/healthz` → green status, Uptime Monitor page displays `http://host:port/healthz`
  - tcpdump confirms `GET /healthz` with the new User-Agent
- Switching back to empty URI restores `GET /` behavior — full backward compat

## UI

The new field appears in two places:
- The "Create New Proxy Rule" form (Advanced Settings, under "Enable uptime monitor")
- The per-host inline editor (Upstream tab, under "Monitor Uptime"), styled consistently with the existing "Connection Timeout" field

---

**Suggested CHANGELOG entry (for next release):**

```
+ Added custom URI for Uptime Monitor health check fixes [#1050](https://github.com/tobychui/zoraxy/issues/1050)
```