### PR TITLE
fix(acme): persist and reuse the ACME account instead of registering a new one on every renewal

### DIFF
--- a/src/mod/acme/account.go
+++ b/src/mod/acme/account.go
@@ -1,0 +1,127 @@
+package acme
+
+import (
+	"crypto/ecdsa"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+
+	"github.com/go-acme/lego/v4/registration"
+)
+
+/*
+	account.go
+
+	This file persists and reuses the ACME account (account key + registration)
+	across certificate requests and renewals.
+
+	Without this, ObtainCert() generated a fresh account key and registered a
+	brand new ACME account on every single call. Let's Encrypt counts each of
+	those as a "new registration" and rate limits them to 10 per IP per 3h, so
+	routine renewals would eventually fail with:
+
+		urn:ietf:params:acme:error:rateLimited :: too many new registrations
+
+	The account is stored in the system database, in the same "acme" table and
+	keyed by the same CA directory URL already used for this provider's EAB
+	credentials (see ObtainCert). It is keyed by the CA directory URL only (NOT
+	the email): an ACME account is identified by its key pair, the email is just
+	a contact address. Keying by CA URL alone means a renewal still reuses the
+	account even if the renewer email differs from the email used at first
+	issuance.
+*/
+
+// acmeAccountTable is the database table reusable ACME accounts are stored in.
+// It is intentionally the same table used for this module's DNS and EAB
+// credentials so all per-CA ACME state lives together.
+const acmeAccountTable = "acme"
+
+// acmeAccountStore is the stored representation of a reusable ACME account.
+type acmeAccountStore struct {
+	Email         string                 `json:"email"`
+	Registration  *registration.Resource `json:"registration"`
+	PrivateKeyPEM string                 `json:"private_key_pem"`
+}
+
+// accountDBKey returns the database key for the account of a given CA
+// directory URL. It mirrors the "<caDirURL>_<field>" key convention this
+// module already uses for EAB (kid/hmacEncoded) credentials.
+func accountDBKey(caDirURL string) string {
+	return caDirURL + "_account"
+}
+
+// loadACMEAccount tries to load a previously persisted account for the given
+// CA directory URL. It returns (key, registration, true) only when a complete,
+// reusable account is found; otherwise ok is false and the caller should
+// register a new account.
+func (a *ACMEHandler) loadACMEAccount(caDirURL string) (*ecdsa.PrivateKey, *registration.Resource, bool) {
+	if !a.Database.TableExists(acmeAccountTable) {
+		// No ACME table yet (first run) - not an error.
+		return nil, nil, false
+	}
+
+	dbKey := accountDBKey(caDirURL)
+	if !a.Database.KeyExists(acmeAccountTable, dbKey) {
+		// No stored account for this CA yet - not an error.
+		return nil, nil, false
+	}
+
+	var store acmeAccountStore
+	if err := a.Database.Read(acmeAccountTable, dbKey, &store); err != nil {
+		a.Logf("Stored ACME account for "+caDirURL+" is invalid, registering a new account", err)
+		return nil, nil, false
+	}
+
+	block, _ := pem.Decode([]byte(store.PrivateKeyPEM))
+	if block == nil {
+		a.Logf("Stored ACME account key for "+caDirURL+" could not be decoded, registering a new account", nil)
+		return nil, nil, false
+	}
+
+	key, err := x509.ParseECPrivateKey(block.Bytes)
+	if err != nil {
+		a.Logf("Stored ACME account key for "+caDirURL+" could not be parsed, registering a new account", err)
+		return nil, nil, false
+	}
+
+	if store.Registration == nil || store.Registration.URI == "" {
+		// A key without a usable registration URI cannot be reused on its own.
+		return nil, nil, false
+	}
+
+	return key, store.Registration, true
+}
+
+// saveACMEAccount persists the account (key + registration) so that subsequent
+// certificate requests and renewals reuse it instead of registering a new
+// ACME account every time.
+func (a *ACMEHandler) saveACMEAccount(caDirURL string, user *ACMEUser) error {
+	if user == nil || user.GetRegistration() == nil {
+		return errors.New("no ACME registration to persist")
+	}
+
+	ecKey, ok := user.GetPrivateKey().(*ecdsa.PrivateKey)
+	if !ok {
+		return errors.New("ACME account private key is not an ECDSA key")
+	}
+
+	der, err := x509.MarshalECPrivateKey(ecKey)
+	if err != nil {
+		return err
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: der})
+
+	store := acmeAccountStore{
+		Email:         user.GetEmail(),
+		Registration:  user.GetRegistration(),
+		PrivateKeyPEM: string(keyPEM),
+	}
+
+	if !a.Database.TableExists(acmeAccountTable) {
+		if err := a.Database.NewTable(acmeAccountTable); err != nil {
+			return err
+		}
+	}
+
+	return a.Database.Write(acmeAccountTable, accountDBKey(caDirURL), &store)
+}

--- a/src/mod/acme/acme.go
+++ b/src/mod/acme/acme.go
@@ -181,6 +181,20 @@ func (a *ACMEHandler) ObtainCert(domains []string, certificateName string, email
 		}
 	}
 
+	// Reuse a previously registered ACME account for this CA if one is stored
+	// in the database. Generating a fresh account key on every call makes
+	// Let's Encrypt treat every renewal as a brand new registration, which
+	// hits the "new registrations per IP" rate limit. config.CADirURL is fully
+	// resolved by this point, and lego.NewClient (below) reads the user key
+	// lazily, so overriding adminUser.key/Registration here is safe.
+	accountLoaded := false
+	if loadedKey, loadedReg, ok := a.loadACMEAccount(config.CADirURL); ok {
+		adminUser.key = loadedKey
+		adminUser.Registration = loadedReg
+		accountLoaded = true
+		a.Logf("Reusing existing ACME account for "+config.CADirURL, nil)
+	}
+
 	config.Certificate.KeyType = certcrypto.RSA2048
 
 	client, err := lego.NewClient(config)
@@ -264,8 +278,12 @@ func (a *ACMEHandler) ObtainCert(domains []string, certificateName string, email
 		}
 	*/
 	var reg *registration.Resource
-	// New users will need to register
-	if client.GetExternalAccountRequired() {
+	// New users will need to register. If we reused an account loaded from
+	// disk, it is already registered - registering again would count against
+	// the CA's "new registrations per IP" rate limit, so skip it entirely.
+	if accountLoaded {
+		reg = adminUser.Registration
+	} else if client.GetExternalAccountRequired() {
 		a.Logf("External Account Required for this ACME Provider", nil)
 		// IF KID and HmacEncoded is overidden
 
@@ -313,6 +331,16 @@ func (a *ACMEHandler) ObtainCert(domains []string, certificateName string, email
 		}
 	}
 	adminUser.Registration = reg
+
+	// Persist a freshly registered account so future certificate requests and
+	// renewals reuse it instead of registering a brand new account each time.
+	if !accountLoaded && reg != nil {
+		if serr := a.saveACMEAccount(config.CADirURL, &adminUser); serr != nil {
+			a.Logf("Failed to persist ACME account (renewals may hit rate limits)", serr)
+		} else {
+			a.Logf("Persisted ACME account for reuse on "+config.CADirURL, nil)
+		}
+	}
 
 	// obtain the certificate
 	request := certificate.ObtainRequest{


### PR DESCRIPTION
fix(acme): reuse one ACME account instead of registering a new one on every renewal

## Problem

`ACMEHandler.ObtainCert()` generates a fresh ECDSA account key with
`ecdsa.GenerateKey()` and calls `client.Registration.Register()` on **every**
certificate request and renewal (`src/mod/acme/acme.go`).

An ACME account is identified by its key pair, so a new key = a new account.
The CA therefore counts **every renewal as a brand-new account registration**.

[Let's Encrypt limits new account registrations to **10 per IP per 3 hours**](https://letsencrypt.org/docs/rate-limits/).
On any instance with more than ~10 certificates, the daily auto-renew pass
exhausts that limit and every remaining certificate fails with:

```
acme: error: 429 :: POST :: https://acme-v02.api.letsencrypt.org/acme/new-acct
:: urn:ietf:params:acme:error:rateLimited
:: too many new registrations (10) from this IP address in the last 3h0m0s
```

Because the old certificate keeps serving traffic until it actually expires,
the failure is silent and is easily misdiagnosed as a CA or DNS outage. On a
real instance with ~90 certificates this resulted in thousands of 429s and only
a handful of certs renewing per day.

Let's Encrypt's own docs explicitly call out "deleting your ACME client's
configuration data each time you deploy" as a common way to hit this limit —
which is effectively what happens on every renewal today.

## Fix

Add `src/mod/acme/account.go`, which persists the account key + registration
resource and reuses it on subsequent calls.

> **Note:** This was originally implemented as a standalone
> `./conf/acme/accounts/<ca>.json` file. Per review feedback from
> @tobychui ([comment](https://github.com/tobychui/zoraxy/pull/1179#issuecomment-4474833940)),
> it now stores via `a.Database` instead — see *Design notes*.

The account is stored through `a.Database` in the **existing `acme` table**,
under the key `<caDirURL>_account`. This is the same table and the same
per-CA key convention this module already uses for its DNS credentials and
EAB `kid`/`hmacEncoded` credentials a few lines away in `ObtainCert()`.

`ObtainCert()` now:

- loads an existing account for the resolved CA directory URL and, if found,
  reuses its key + registration and **skips `Register()` entirely** (no
  new-registration request is sent to the CA);
- otherwise registers exactly as before and persists the result, so a CA is
  only ever hit with a new registration at most once.

## Design notes

- **Stored in the database, not a standalone file.** Keeps all per-CA ACME
  state (DNS creds, EAB `kid`/`hmac`, and now the account) together in the one
  `acme` table, and lets the DB backend own persistence, atomicity and on-disk
  protection. This also removes the bespoke filename sanitisation, directory
  creation and manual `0600`/`0700` permission handling the file version
  needed (~60 fewer lines). The account key is a credential, but it is no more
  sensitive than the EAB HMAC secret already stored in this same table, so
  there is no change to the trust boundary. Thanks @tobychui for pointing at
  `a.Database`.
- **Keyed by the CA directory URL, not the email.** An account is identified by
  its key pair; the email is just a contact address. Keying by CA URL means a
  renewal still reuses the account even if the auto-renewer email differs from
  the email used at first issuance, and staging/custom CAs automatically get
  separate accounts.
- **Backward compatible.** With no stored account (existing installs, first
  run) it falls back to the previous register-new behaviour and then persists
  it, so a CA is hit with a new registration at most once. Installs that ran an
  earlier file-based build of this branch simply re-register once on the next
  renewal (bounded: one per CA, well under the 10/3h limit) and are on the DB
  store from then on — no migration shim required.
- **EAB preserved.** The External Account Binding path is unchanged for the
  not-loaded case.

## Testing

`go build ./...` and `go vet ./mod/acme/` are clean.

Verified on a production instance (~90 certs, Let's Encrypt prod) that
previously suffered the 429 storm:

- **First `ObtainCert` after deploy:** registered once and logged
  `Persisted ACME account for reuse on https://acme-v02.api.letsencrypt.org/directory`
  (DB write path).
- **Next `ObtainCert` (after a restart):** logged
  `Reusing existing ACME account for https://acme-v02.api.letsencrypt.org/directory`,
  with **0** `new-acct` registrations and **0** `rateLimited` errors
  (DB read path).
- Net effect across the renew pass: exactly one registration per CA, reused for
  all subsequent certs — the rate-limit storm is gone.

Staging vs production and custom CAs get independent account entries
(distinct `<caDirURL>_account` keys in the `acme` table).
