### PR TITLE
fix: migrate ACME DNS credentials when setting fallback certificate

### DIFF
--- a/src/mod/acme/acme.go
+++ b/src/mod/acme/acme.go
@@ -102,6 +102,29 @@ func (a *ACMEHandler) Logf(message string, err error) {
 	a.Logger.PrintAndLog("ACME", message, err)
 }
 
+// MigrateACMEDNSConfig moves the DNS credential database entries stored under
+// oldName to newName, then removes the old keys. This must be called whenever a
+// certificate file is renamed (e.g. when it is promoted to or demoted from the
+// fallback/default certificate) so that auto-renewal can still locate the
+// correct DNS challenge credentials by the new filename.
+func (a *ACMEHandler) MigrateACMEDNSConfig(oldName, newName string) {
+	if !a.Database.TableExists("acme") {
+		return
+	}
+	for _, suffix := range []string{"_dns_provider", "_dns_credentials", "_dns_servers"} {
+		oldKey := oldName + suffix
+		newKey := newName + suffix
+		if !a.Database.KeyExists("acme", oldKey) {
+			continue
+		}
+		var value string
+		if err := a.Database.Read("acme", oldKey, &value); err == nil {
+			a.Database.Write("acme", newKey, value)
+			a.Database.Delete("acme", oldKey)
+		}
+	}
+}
+
 // Close closes the ACMEHandler.
 // ACME Handler does not need to close anything
 // Function defined for future compatibility

--- a/src/mod/tlscert/handler.go
+++ b/src/mod/tlscert/handler.go
@@ -96,14 +96,21 @@ func (m *Manager) SetCertAsDefault(w http.ResponseWriter, r *http.Request) {
 			if block != nil {
 				cert, err := x509.ParseCertificate(block.Bytes)
 				if err == nil {
-					originalKeyName := filepath.Join(m.CertStore, domainToFilename(cert.Subject.CommonName, "key"))
 					originalPemName := filepath.Join(m.CertStore, domainToFilename(cert.Subject.CommonName, "pem"))
+					originalKeyName := filepath.Join(m.CertStore, domainToFilename(cert.Subject.CommonName, "key"))
 					originalJSONName := filepath.Join(m.CertStore, domainToFilename(cert.Subject.CommonName, "json"))
 
 					os.Rename(defaultPubKey, originalPemName)
 					os.Rename(defaultPriKey, originalKeyName)
 					if utils.FileExists(defaultJSON) {
 						os.Rename(defaultJSON, originalJSONName)
+					}
+
+					// Migrate ACME DNS credentials from "default" back to the
+					// original certificate name so renewal can find them again.
+					if m.AcmeHandler != nil {
+						originalCertName := strings.TrimSuffix(filepath.Base(originalPemName), ".pem")
+						m.AcmeHandler.MigrateACMEDNSConfig("default", originalCertName)
 					}
 				}
 			}
@@ -121,6 +128,13 @@ func (m *Manager) SetCertAsDefault(w http.ResponseWriter, r *http.Request) {
 		if utils.FileExists(certJSON) {
 			os.Rename(certJSON, filepath.Join(m.CertStore, "default.json"))
 		}
+
+		// Migrate ACME DNS credentials to "default" so that auto-renewal can
+		// locate them by the new filename.
+		if m.AcmeHandler != nil {
+			m.AcmeHandler.MigrateACMEDNSConfig(certname, "default")
+		}
+
 		utils.SendOK(w)
 
 		//Update cert list

--- a/src/mod/tlscert/tlscert.go
+++ b/src/mod/tlscert/tlscert.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"imuslab.com/zoraxy/mod/acme"
 	"imuslab.com/zoraxy/mod/info/logger"
 	"imuslab.com/zoraxy/mod/utils"
 )
@@ -34,6 +35,7 @@ type Manager struct {
 	Logger      *logger.Logger //System wide logger for debug mesage
 
 	/* External handlers */
+	AcmeHandler             *acme.ACMEHandler                                          // Optional: used to migrate DNS credentials when a cert is renamed
 	hostSpecificTlsBehavior func(serverName string) (*HostSpecificTlsBehavior, error) // Function to get host specific TLS behavior, if nil, use global TLS options
 }
 

--- a/src/start.go
+++ b/src/start.go
@@ -346,6 +346,11 @@ func startupSequence() {
 		log.Fatal(err)
 	}
 
+	// Give the cert manager a reference to the ACME handler so that it can
+	// migrate DNS credential database keys whenever a certificate is renamed
+	// (e.g. when it is promoted to the fallback/default certificate).
+	tlsCertManager.AcmeHandler = acmeHandler
+
 	/*
 		Plugin Manager
 	*/


### PR DESCRIPTION
## Problem

When a user clicks **Set as Default / Fallback Certificate**, the cert files are
renamed from `{hostname}.{pem,key,json}` to `default.{pem,key,json}`. However
the ACME database entries for DNS challenge credentials remain keyed by the
original hostname:

```
{hostname}_dns_provider
{hostname}_dns_credentials
{hostname}_dns_servers
```

During auto-renewal (and manual renewal via **Renew Now**), `renewExpiredDomains`
derives the certificate name from the on-disk filename — which is now `default`
— and looks up `default_dns_provider` / `default_dns_credentials` in the database.
Those keys do not exist, so the renewal fails.

Closes #1124

## Solution

- Add `ACMEHandler.MigrateACMEDNSConfig(oldName, newName string)` which copies
  `_dns_provider`, `_dns_credentials`, and `_dns_servers` database keys from
  `oldName` to `newName` and removes the originals.
- Call it inside `tlscert.Manager.SetCertAsDefault` at two points:
  1. When the **previous** default cert is restored to its original filename
     (`"default"` → original name), so its credentials remain findable.
  2. When the **new** cert is renamed to `default` (`certname` → `"default"`),
     so renewal can look them up by the new filename.
- Store an `*acme.ACMEHandler` reference on `tlscert.Manager` and wire it in
  `start.go` after both components are initialised.

## Test plan

- [ ] Configure a certificate with ACME DNS challenge credentials (provider + token).
- [ ] Click **Set as Default** for that certificate.
- [ ] Verify the cert files are renamed to `default.*` as before.
- [ ] Trigger **Renew Now** — renewal should succeed using the migrated
      `default_dns_provider` / `default_dns_credentials` keys.
- [ ] Set a different certificate as default; verify the first cert is restored
      with its original credentials intact and renewal works for it too.
- [ ] Certificates without DNS credentials (HTTP-01 challenge) are unaffected.