### PR TITLE
Add Prometheus exporter example plugin

### DIFF
--- a/example/plugins/prometheus-exporter/go.mod
+++ b/example/plugins/prometheus-exporter/go.mod
@@ -1,0 +1,3 @@
+module example.com/zoraxy/prometheus-exporter
+
+go 1.23.6

--- a/example/plugins/prometheus-exporter/main.go
+++ b/example/plugins/prometheus-exporter/main.go
@@ -1,0 +1,323 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	plugin "example.com/zoraxy/prometheus-exporter/mod/zoraxy_plugin"
+)
+
+const (
+	PLUGIN_ID    = "com.example.zoraxy.prometheus-exporter"
+	UI_PATH      = "/ui"
+	METRICS_PATH = "/metrics"
+)
+
+// DailySummaryExport mirrors the structure returned by /api/stats/summary.
+// High-cardinality fields (RequestClientIp, Referer, UserAgent, RequestURL)
+// are intentionally omitted to avoid label cardinality explosion in Prometheus.
+type DailySummaryExport struct {
+	TotalRequest  int64          `json:"TotalRequest"`
+	ErrorRequest  int64          `json:"ErrorRequest"`
+	ValidRequest  int64          `json:"ValidRequest"`
+	ForwardTypes  map[string]int `json:"ForwardTypes"`
+	RequestOrigin map[string]int `json:"RequestOrigin"`
+	Downstreams   map[string]int `json:"Downstreams"`
+	Upstreams     map[string]int `json:"Upstreams"`
+}
+
+type NetStat struct {
+	RX int64 `json:"RX"`
+	TX int64 `json:"TX"`
+}
+
+type metricsState struct {
+	mu         sync.RWMutex
+	summary    *DailySummaryExport
+	netstat    *NetStat
+	lastUpdate time.Time
+	lastError  string
+}
+
+var (
+	state      metricsState
+	runtimeCfg *plugin.ConfigureSpec
+)
+
+func sortedKeys(m map[string]int) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func escapeLabel(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `"`, `\"`)
+	s = strings.ReplaceAll(s, "\n", `\n`)
+	return s
+}
+
+func fetchStats() {
+	client := &http.Client{Timeout: 10 * time.Second}
+
+	doGet := func(apiPath string) ([]byte, error) {
+		url := fmt.Sprintf("http://127.0.0.1:%d/plugin%s", runtimeCfg.ZoraxyPort, apiPath)
+		req, err := http.NewRequest(http.MethodGet, url, nil)
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Authorization", "Bearer "+runtimeCfg.APIKey)
+		resp, err := client.Do(req)
+		if err != nil {
+			return nil, err
+		}
+		defer resp.Body.Close()
+		return io.ReadAll(resp.Body)
+	}
+
+	summaryBody, err := doGet("/api/stats/summary")
+	if err != nil {
+		state.mu.Lock()
+		state.lastError = "summary fetch: " + err.Error()
+		state.mu.Unlock()
+		return
+	}
+
+	var summary DailySummaryExport
+	if err := json.Unmarshal(summaryBody, &summary); err != nil {
+		state.mu.Lock()
+		state.lastError = "summary parse: " + err.Error()
+		state.mu.Unlock()
+		return
+	}
+
+	var ns *NetStat
+	if netBody, err := doGet("/api/stats/netstat"); err == nil {
+		var tmp NetStat
+		if json.Unmarshal(netBody, &tmp) == nil {
+			ns = &tmp
+		}
+	}
+
+	state.mu.Lock()
+	state.summary = &summary
+	state.netstat = ns
+	state.lastUpdate = time.Now()
+	state.lastError = ""
+	state.mu.Unlock()
+}
+
+func startPoller() {
+	go func() {
+		fetchStats()
+		ticker := time.NewTicker(30 * time.Second)
+		for range ticker.C {
+			fetchStats()
+		}
+	}()
+}
+
+func handleMetrics(w http.ResponseWriter, r *http.Request) {
+	state.mu.RLock()
+	defer state.mu.RUnlock()
+
+	w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+
+	if state.summary == nil {
+		if state.lastError != "" {
+			fmt.Fprintf(w, "# ERROR %s\n", state.lastError)
+		} else {
+			fmt.Fprintln(w, "# Waiting for first data fetch...")
+		}
+		return
+	}
+
+	s := state.summary
+
+	writeGauge := func(name, help string, value int64) {
+		fmt.Fprintf(w, "# HELP %s %s\n# TYPE %s gauge\n%s %d\n", name, help, name, name, value)
+	}
+
+	writeLabeledGauge := func(name, help, labelKey string, m map[string]int) {
+		if len(m) == 0 {
+			return
+		}
+		fmt.Fprintf(w, "# HELP %s %s\n# TYPE %s gauge\n", name, help, name)
+		for _, k := range sortedKeys(m) {
+			fmt.Fprintf(w, "%s{%s=\"%s\"} %d\n", name, labelKey, escapeLabel(k), m[k])
+		}
+	}
+
+	writeGauge("zoraxy_requests_today_total", "Total requests proxied today", s.TotalRequest)
+	writeGauge("zoraxy_requests_today_valid", "Valid requests today", s.ValidRequest)
+	writeGauge("zoraxy_requests_today_error", "Error requests today", s.ErrorRequest)
+
+	writeLabeledGauge("zoraxy_requests_by_forward_type", "Requests by forward type today", "type", s.ForwardTypes)
+	writeLabeledGauge("zoraxy_requests_by_country", "Requests by origin country ISO code today", "country", s.RequestOrigin)
+	writeLabeledGauge("zoraxy_requests_by_downstream", "Requests by downstream hostname today", "hostname", s.Downstreams)
+	writeLabeledGauge("zoraxy_requests_by_upstream", "Requests by upstream hostname today", "hostname", s.Upstreams)
+
+	if state.netstat != nil {
+		fmt.Fprintln(w, "# HELP zoraxy_network_rx_bits_total Accumulated received bits across all network interfaces")
+		fmt.Fprintln(w, "# TYPE zoraxy_network_rx_bits_total counter")
+		fmt.Fprintf(w, "zoraxy_network_rx_bits_total %d\n", state.netstat.RX)
+		fmt.Fprintln(w, "# HELP zoraxy_network_tx_bits_total Accumulated transmitted bits across all network interfaces")
+		fmt.Fprintln(w, "# TYPE zoraxy_network_tx_bits_total counter")
+		fmt.Fprintf(w, "zoraxy_network_tx_bits_total %d\n", state.netstat.TX)
+	}
+
+	fmt.Fprintln(w, "# HELP zoraxy_stats_last_update_unix Unix timestamp of last successful stats fetch")
+	fmt.Fprintln(w, "# TYPE zoraxy_stats_last_update_unix gauge")
+	fmt.Fprintf(w, "zoraxy_stats_last_update_unix %d\n", state.lastUpdate.Unix())
+}
+
+func handleUI(metricsPort int) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		state.mu.RLock()
+		lastUpdate := state.lastUpdate
+		lastError := state.lastError
+		var total, valid, errs int64
+		if state.summary != nil {
+			total = state.summary.TotalRequest
+			valid = state.summary.ValidRequest
+			errs = state.summary.ErrorRequest
+		}
+		state.mu.RUnlock()
+
+		var statusDiv string
+		switch {
+		case lastError != "":
+			statusDiv = `<div class="ui red message"><i class="warning icon"></i>Fetch error: ` + lastError + `</div>`
+		case !lastUpdate.IsZero():
+			statusDiv = `<div class="ui green message"><i class="check icon"></i>Last updated: ` + lastUpdate.Format("2006-01-02 15:04:05") + `</div>`
+		default:
+			statusDiv = `<div class="ui yellow message"><i class="clock icon"></i>Waiting for first fetch...</div>`
+		}
+
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		fmt.Fprintf(w, `<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>Prometheus Exporter</title>
+<link rel="stylesheet" href="/script/semantic/semantic.min.css">
+<link rel="stylesheet" href="/main.css">
+<style>body{background:none}</style>
+</head>
+<body>
+<link rel="stylesheet" href="/darktheme.css">
+<script src="/script/darktheme.js"></script>
+<div class="ui container" style="padding-top:1.5em">
+<h2 class="ui header">Prometheus Exporter</h2>
+<p>Exposes Zoraxy statistical analysis data as Prometheus metrics.</p>
+%s
+<div class="ui segment">
+<h4>Metrics Endpoint</h4>
+<code>http://&lt;host&gt;:%d/metrics</code>
+<p style="margin-top:.5em;color:gray;font-size:.9em">Configure Prometheus to scrape this endpoint. Stats are fetched from Zoraxy every 30 seconds.</p>
+</div>
+<div class="ui segment">
+<h4>Today's Requests</h4>
+<div class="ui three statistics">
+<div class="statistic"><div class="value">%d</div><div class="label">Total</div></div>
+<div class="statistic"><div class="value">%d</div><div class="label">Valid</div></div>
+<div class="statistic"><div class="value">%d</div><div class="label">Errors</div></div>
+</div>
+</div>
+</div>
+</body>
+</html>`, statusDiv, metricsPort, total, valid, errs)
+	}
+}
+
+// parseMetricsPort reads -metrics-port=N from os.Args without using the flag
+// package, which would conflict with Zoraxy's own -configure and -introspect flags.
+func parseMetricsPort() int {
+	for _, arg := range os.Args[1:] {
+		for _, prefix := range []string{"-metrics-port=", "--metrics-port="} {
+			if strings.HasPrefix(arg, prefix) {
+				if p, err := strconv.Atoi(arg[len(prefix):]); err == nil && p > 0 && p < 65536 {
+					return p
+				}
+			}
+		}
+	}
+	return 9100
+}
+
+func main() {
+	metricsPort := parseMetricsPort()
+
+	cfg, err := plugin.ServeAndRecvSpec(&plugin.IntroSpect{
+		ID:            PLUGIN_ID,
+		Name:          "Prometheus Exporter",
+		Author:        "Zoraxy",
+		AuthorContact: "",
+		Description:   "Exports Zoraxy statistical analysis data as Prometheus metrics",
+		Type:          plugin.PluginType_Utilities,
+		VersionMajor:  1,
+		VersionMinor:  0,
+		VersionPatch:  0,
+		UIPath:        UI_PATH,
+		PermittedAPIEndpoints: []plugin.PermittedAPIEndpoint{
+			{
+				Method:   http.MethodGet,
+				Endpoint: "/plugin/api/stats/summary",
+				Reason:   "Fetch daily request statistics for Prometheus export",
+			},
+			{
+				Method:   http.MethodGet,
+				Endpoint: "/plugin/api/stats/netstat",
+				Reason:   "Fetch network interface statistics for Prometheus export",
+			},
+		},
+	})
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "startup error:", err)
+		os.Exit(1)
+	}
+	runtimeCfg = cfg
+
+	startPoller()
+
+	// Dedicated metrics server on all interfaces for Prometheus scraping.
+	metricsMux := http.NewServeMux()
+	metricsMux.HandleFunc(METRICS_PATH, handleMetrics)
+	go func() {
+		addr := ":" + strconv.Itoa(metricsPort)
+		fmt.Println("Metrics server listening on", addr)
+		if err := http.ListenAndServe(addr, metricsMux); err != nil {
+			fmt.Fprintln(os.Stderr, "metrics server:", err)
+		}
+	}()
+
+	// Plugin server on localhost only for Zoraxy UI integration.
+	mux := http.NewServeMux()
+	mux.HandleFunc(UI_PATH+"/", handleUI(metricsPort))
+	mux.HandleFunc(METRICS_PATH, handleMetrics)
+	mux.HandleFunc(UI_PATH+"/term", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		go func() {
+			time.Sleep(100 * time.Millisecond)
+			os.Exit(0)
+		}()
+	})
+
+	pluginAddr := "127.0.0.1:" + strconv.Itoa(cfg.Port)
+	fmt.Println("Plugin server listening on", pluginAddr)
+	if err := http.ListenAndServe(pluginAddr, mux); err != nil {
+		fmt.Fprintln(os.Stderr, "plugin server:", err)
+		os.Exit(1)
+	}
+}

--- a/example/plugins/prometheus-exporter/mod/zoraxy_plugin/dev_webserver.go
+++ b/example/plugins/prometheus-exporter/mod/zoraxy_plugin/dev_webserver.go
@@ -1,0 +1,145 @@
+package zoraxy_plugin
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+type PluginUiDebugRouter struct {
+	PluginID         string //The ID of the plugin
+	TargetDir        string //The directory where the UI files are stored
+	HandlerPrefix    string //The prefix of the handler used to route this router, e.g. /ui
+	EnableDebug      bool   //Enable debug mode
+	terminateHandler func() //The handler to be called when the plugin is terminated
+}
+
+// NewPluginFileSystemUIRouter creates a new PluginUiRouter with file system
+// The targetDir is the directory where the UI files are stored (e.g. ./www)
+// The handlerPrefix is the prefix of the handler used to route this router
+// The handlerPrefix should start with a slash (e.g. /ui) that matches the http.Handle path
+// All prefix should not end with a slash
+func NewPluginFileSystemUIRouter(pluginID string, targetDir string, handlerPrefix string) *PluginUiDebugRouter {
+	//Make sure all prefix are in /prefix format
+	if !strings.HasPrefix(handlerPrefix, "/") {
+		handlerPrefix = "/" + handlerPrefix
+	}
+	handlerPrefix = strings.TrimSuffix(handlerPrefix, "/")
+
+	//Return the PluginUiRouter
+	return &PluginUiDebugRouter{
+		PluginID:      pluginID,
+		TargetDir:     targetDir,
+		HandlerPrefix: handlerPrefix,
+	}
+}
+
+func (p *PluginUiDebugRouter) populateCSRFToken(r *http.Request, fsHandler http.Handler) http.Handler {
+	//Get the CSRF token from header
+	csrfToken := r.Header.Get("X-Zoraxy-Csrf")
+	if csrfToken == "" {
+		csrfToken = "missing-csrf-token"
+	}
+
+	//Return the middleware
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Check if the request is for an HTML file
+		if strings.HasSuffix(r.URL.Path, ".html") {
+			//Read the target file from file system
+			targetFilePath := strings.TrimPrefix(r.URL.Path, "/")
+			targetFilePath = p.TargetDir + "/" + targetFilePath
+			targetFilePath = strings.TrimPrefix(targetFilePath, "/")
+			targetFileContent, err := os.ReadFile(targetFilePath)
+			if err != nil {
+				http.Error(w, "File not found", http.StatusNotFound)
+				return
+			}
+			body := string(targetFileContent)
+			body = strings.ReplaceAll(body, "{{.csrfToken}}", csrfToken)
+			w.Header().Set("Content-Type", "text/html")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(body))
+			return
+		} else if strings.HasSuffix(r.URL.Path, "/") {
+			//Check if the request is for a directory
+			//Check if the directory has an index.html file
+			targetFilePath := strings.TrimPrefix(r.URL.Path, "/")
+			targetFilePath = p.TargetDir + "/" + targetFilePath + "index.html"
+			targetFilePath = strings.TrimPrefix(targetFilePath, "/")
+			if _, err := os.Stat(targetFilePath); err == nil {
+				//Serve the index.html file
+				targetFileContent, err := os.ReadFile(targetFilePath)
+				if err != nil {
+					http.Error(w, "File not found", http.StatusNotFound)
+					return
+				}
+				body := string(targetFileContent)
+				body = strings.ReplaceAll(body, "{{.csrfToken}}", csrfToken)
+				w.Header().Set("Content-Type", "text/html")
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(body))
+				return
+			}
+		}
+
+		//Call the next handler
+		fsHandler.ServeHTTP(w, r)
+	})
+
+}
+
+// GetHttpHandler returns the http.Handler for the PluginUiRouter
+func (p *PluginUiDebugRouter) Handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		//Remove the plugin UI handler path prefix
+		if p.EnableDebug {
+			fmt.Print("Request URL:", r.URL.Path, " rewriting to ")
+		}
+
+		rewrittenURL := r.RequestURI
+		rewrittenURL = strings.TrimPrefix(rewrittenURL, p.HandlerPrefix)
+		rewrittenURL = strings.ReplaceAll(rewrittenURL, "//", "/")
+		r.URL.Path = rewrittenURL
+		r.RequestURI = rewrittenURL
+		if p.EnableDebug {
+			fmt.Println(r.URL.Path)
+		}
+
+		//Serve the file from the file system
+		fsHandler := http.FileServer(http.Dir(p.TargetDir))
+
+		// Replace {{csrf_token}} with the actual CSRF token and serve the file
+		p.populateCSRFToken(r, fsHandler).ServeHTTP(w, r)
+	})
+}
+
+// RegisterTerminateHandler registers the terminate handler for the PluginUiRouter
+// The terminate handler will be called when the plugin is terminated from Zoraxy plugin manager
+// if mux is nil, the handler will be registered to http.DefaultServeMux
+func (p *PluginUiDebugRouter) RegisterTerminateHandler(termFunc func(), mux *http.ServeMux) {
+	p.terminateHandler = termFunc
+	if mux == nil {
+		mux = http.DefaultServeMux
+	}
+	mux.HandleFunc(p.HandlerPrefix+"/term", func(w http.ResponseWriter, r *http.Request) {
+		p.terminateHandler()
+		w.WriteHeader(http.StatusOK)
+		go func() {
+			//Make sure the response is sent before the plugin is terminated
+			time.Sleep(100 * time.Millisecond)
+			os.Exit(0)
+		}()
+	})
+}
+
+// Attach the file system UI handler to the target http.ServeMux
+func (p *PluginUiDebugRouter) AttachHandlerToMux(mux *http.ServeMux) {
+	if mux == nil {
+		mux = http.DefaultServeMux
+	}
+
+	p.HandlerPrefix = strings.TrimSuffix(p.HandlerPrefix, "/")
+	mux.Handle(p.HandlerPrefix+"/", p.Handler())
+}

--- a/example/plugins/prometheus-exporter/mod/zoraxy_plugin/dynamic_router.go
+++ b/example/plugins/prometheus-exporter/mod/zoraxy_plugin/dynamic_router.go
@@ -1,0 +1,162 @@
+package zoraxy_plugin
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+/*
+
+	Dynamic Path Handler
+
+*/
+
+type SniffResult int
+
+const (
+	SniffResultAccept SniffResult = iota // Forward the request to this plugin dynamic capture ingress
+	SniffResultSkip                      // Skip this plugin and let the next plugin handle the request
+)
+
+type SniffHandler func(*DynamicSniffForwardRequest) SniffResult
+
+/*
+RegisterDynamicSniffHandler registers a dynamic sniff handler for a path
+You can decide to accept or skip the request based on the request header and paths
+*/
+func (p *PathRouter) RegisterDynamicSniffHandler(sniff_ingress string, mux *http.ServeMux, handler SniffHandler) {
+	if !strings.HasSuffix(sniff_ingress, "/") {
+		sniff_ingress = sniff_ingress + "/"
+	}
+	mux.Handle(sniff_ingress, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if p.enableDebugPrint {
+			fmt.Println("Request captured by dynamic sniff path: " + r.RequestURI)
+		}
+
+		// Decode the request payload
+		jsonBytes, err := io.ReadAll(r.Body)
+		if err != nil {
+			if p.enableDebugPrint {
+				fmt.Println("Error reading request body:", err)
+			}
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			return
+		}
+		payload, err := DecodeForwardRequestPayload(jsonBytes)
+		if err != nil {
+			if p.enableDebugPrint {
+				fmt.Println("Error decoding request payload:", err)
+				fmt.Print("Payload: ")
+				fmt.Println(string(jsonBytes))
+			}
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			return
+		}
+
+		// Get the forwarded request UUID
+		forwardUUID := r.Header.Get("X-Zoraxy-RequestID")
+		payload.requestUUID = forwardUUID
+		payload.rawRequest = r
+
+		sniffResult := handler(&payload)
+		if sniffResult == SniffResultAccept {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("OK"))
+		} else {
+			w.WriteHeader(http.StatusNotImplemented)
+			w.Write([]byte("SKIP"))
+		}
+	}))
+}
+
+// RegisterDynamicCaptureHandle register the dynamic capture ingress path with a handler
+func (p *PathRouter) RegisterDynamicCaptureHandle(capture_ingress string, mux *http.ServeMux, handlefunc func(http.ResponseWriter, *http.Request)) {
+	if !strings.HasSuffix(capture_ingress, "/") {
+		capture_ingress = capture_ingress + "/"
+	}
+	mux.Handle(capture_ingress, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if p.enableDebugPrint {
+			fmt.Println("Request captured by dynamic capture path: " + r.RequestURI)
+		}
+
+		rewrittenURL := r.RequestURI
+		rewrittenURL = strings.TrimPrefix(rewrittenURL, capture_ingress)
+		rewrittenURL = strings.ReplaceAll(rewrittenURL, "//", "/")
+		if rewrittenURL == "" {
+			rewrittenURL = "/"
+		}
+		if !strings.HasPrefix(rewrittenURL, "/") {
+			rewrittenURL = "/" + rewrittenURL
+		}
+		r.RequestURI = rewrittenURL
+
+		handlefunc(w, r)
+	}))
+}
+
+/*
+	Sniffing and forwarding
+
+	The following functions are here to help with
+	sniffing and forwarding requests to the dynamic
+	router.
+*/
+// A custom request object to be used in the dynamic sniffing
+type DynamicSniffForwardRequest struct {
+	Method     string              `json:"method"`
+	Hostname   string              `json:"hostname"`
+	URL        string              `json:"url"`
+	Header     map[string][]string `json:"header"`
+	RemoteAddr string              `json:"remote_addr"`
+	Host       string              `json:"host"`
+	RequestURI string              `json:"request_uri"`
+	Proto      string              `json:"proto"`
+	ProtoMajor int                 `json:"proto_major"`
+	ProtoMinor int                 `json:"proto_minor"`
+
+	/* Internal use */
+	rawRequest  *http.Request `json:"-"`
+	requestUUID string        `json:"-"`
+}
+
+// GetForwardRequestPayload returns a DynamicSniffForwardRequest object from an http.Request object
+func EncodeForwardRequestPayload(r *http.Request) DynamicSniffForwardRequest {
+	return DynamicSniffForwardRequest{
+		Method:     r.Method,
+		Hostname:   r.Host,
+		URL:        r.URL.String(),
+		Header:     r.Header,
+		RemoteAddr: r.RemoteAddr,
+		Host:       r.Host,
+		RequestURI: r.RequestURI,
+		Proto:      r.Proto,
+		ProtoMajor: r.ProtoMajor,
+		ProtoMinor: r.ProtoMinor,
+		rawRequest: r,
+	}
+}
+
+// DecodeForwardRequestPayload decodes JSON bytes into a DynamicSniffForwardRequest object
+func DecodeForwardRequestPayload(jsonBytes []byte) (DynamicSniffForwardRequest, error) {
+	var payload DynamicSniffForwardRequest
+	err := json.Unmarshal(jsonBytes, &payload)
+	if err != nil {
+		return DynamicSniffForwardRequest{}, err
+	}
+	return payload, nil
+}
+
+// GetRequest returns the original http.Request object, for debugging purposes
+func (dsfr *DynamicSniffForwardRequest) GetRequest() *http.Request {
+	return dsfr.rawRequest
+}
+
+// GetRequestUUID returns the request UUID
+// if this UUID is empty string, that might indicate the request
+// is not coming from the dynamic router
+func (dsfr *DynamicSniffForwardRequest) GetRequestUUID() string {
+	return dsfr.requestUUID
+}

--- a/example/plugins/prometheus-exporter/mod/zoraxy_plugin/embed_webserver.go
+++ b/example/plugins/prometheus-exporter/mod/zoraxy_plugin/embed_webserver.go
@@ -1,0 +1,174 @@
+package zoraxy_plugin
+
+import (
+	"embed"
+	"fmt"
+	"io/fs"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+)
+
+type PluginUiRouter struct {
+	PluginID         string    //The ID of the plugin
+	TargetFs         *embed.FS //The embed.FS where the UI files are stored
+	TargetFsPrefix   string    //The prefix of the embed.FS where the UI files are stored, e.g. /web
+	HandlerPrefix    string    //The prefix of the handler used to route this router, e.g. /ui
+	EnableDebug      bool      //Enable debug mode
+	terminateHandler func()    //The handler to be called when the plugin is terminated
+}
+
+// NewPluginEmbedUIRouter creates a new PluginUiRouter with embed.FS
+// The targetFsPrefix is the prefix of the embed.FS where the UI files are stored
+// The targetFsPrefix should be relative to the root of the embed.FS
+// The targetFsPrefix should start with a slash (e.g. /web) that corresponds to the root folder of the embed.FS
+// The handlerPrefix is the prefix of the handler used to route this router
+// The handlerPrefix should start with a slash (e.g. /ui) that matches the http.Handle path
+// All prefix should not end with a slash
+func NewPluginEmbedUIRouter(pluginID string, targetFs *embed.FS, targetFsPrefix string, handlerPrefix string) *PluginUiRouter {
+	//Make sure all prefix are in /prefix format
+	if !strings.HasPrefix(targetFsPrefix, "/") {
+		targetFsPrefix = "/" + targetFsPrefix
+	}
+	targetFsPrefix = strings.TrimSuffix(targetFsPrefix, "/")
+
+	if !strings.HasPrefix(handlerPrefix, "/") {
+		handlerPrefix = "/" + handlerPrefix
+	}
+	handlerPrefix = strings.TrimSuffix(handlerPrefix, "/")
+
+	//Return the PluginUiRouter
+	return &PluginUiRouter{
+		PluginID:       pluginID,
+		TargetFs:       targetFs,
+		TargetFsPrefix: targetFsPrefix,
+		HandlerPrefix:  handlerPrefix,
+	}
+}
+
+func (p *PluginUiRouter) populateCSRFToken(r *http.Request, fsHandler http.Handler) http.Handler {
+	//Get the CSRF token from header
+	csrfToken := r.Header.Get("X-Zoraxy-Csrf")
+	if csrfToken == "" {
+		csrfToken = "missing-csrf-token"
+	}
+
+	//Return the middleware
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Check if the request is for an HTML file
+		if strings.HasSuffix(r.URL.Path, ".html") {
+			//Read the target file from embed.FS
+			targetFilePath := strings.TrimPrefix(r.URL.Path, "/")
+			targetFilePath = p.TargetFsPrefix + "/" + targetFilePath
+			targetFilePath = strings.TrimPrefix(targetFilePath, "/")
+			targetFileContent, err := fs.ReadFile(*p.TargetFs, targetFilePath)
+			if err != nil {
+				http.Error(w, "File not found", http.StatusNotFound)
+				return
+			}
+			body := string(targetFileContent)
+			body = strings.ReplaceAll(body, "{{.csrfToken}}", csrfToken)
+			w.Header().Set("Content-Type", "text/html")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(body))
+			return
+		} else if strings.HasSuffix(r.URL.Path, "/") {
+			// Check if the directory has an index.html file
+			indexFilePath := strings.TrimPrefix(r.URL.Path, "/") + "index.html"
+			indexFilePath = p.TargetFsPrefix + "/" + indexFilePath
+			indexFilePath = strings.TrimPrefix(indexFilePath, "/")
+			indexFileContent, err := fs.ReadFile(*p.TargetFs, indexFilePath)
+			if err == nil {
+				body := string(indexFileContent)
+				body = strings.ReplaceAll(body, "{{.csrfToken}}", csrfToken)
+				w.Header().Set("Content-Type", "text/html")
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(body))
+				return
+			}
+		}
+
+		//Call the next handler
+		fsHandler.ServeHTTP(w, r)
+	})
+
+}
+
+// GetHttpHandler returns the http.Handler for the PluginUiRouter
+func (p *PluginUiRouter) Handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		//Remove the plugin UI handler path prefix
+		if p.EnableDebug {
+			fmt.Print("Request URL:", r.URL.Path, " rewriting to ")
+		}
+
+		rewrittenURL := r.RequestURI
+		rewrittenURL = strings.TrimPrefix(rewrittenURL, p.HandlerPrefix)
+		rewrittenURL = strings.ReplaceAll(rewrittenURL, "//", "/")
+		r.URL, _ = url.Parse(rewrittenURL)
+		r.RequestURI = rewrittenURL
+		if p.EnableDebug {
+			fmt.Println(r.URL.Path)
+		}
+
+		//Serve the file from the embed.FS
+		subFS, err := fs.Sub(*p.TargetFs, strings.TrimPrefix(p.TargetFsPrefix, "/"))
+		if err != nil {
+			fmt.Println(err.Error())
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			return
+		}
+
+		// Replace {{csrf_token}} with the actual CSRF token and serve the file
+		p.populateCSRFToken(r, http.FileServer(http.FS(subFS))).ServeHTTP(w, r)
+	})
+}
+
+// RegisterTerminateHandler registers the terminate handler for the PluginUiRouter
+// The terminate handler will be called when the plugin is terminated from Zoraxy plugin manager
+// if mux is nil, the handler will be registered to http.DefaultServeMux
+func (p *PluginUiRouter) RegisterTerminateHandler(termFunc func(), mux *http.ServeMux) {
+	p.terminateHandler = termFunc
+	if mux == nil {
+		mux = http.DefaultServeMux
+	}
+	mux.HandleFunc(p.HandlerPrefix+"/term", func(w http.ResponseWriter, r *http.Request) {
+		p.terminateHandler()
+		w.WriteHeader(http.StatusOK)
+		go func() {
+			//Make sure the response is sent before the plugin is terminated
+			time.Sleep(100 * time.Millisecond)
+			os.Exit(0)
+		}()
+	})
+}
+
+// HandleFunc registers a handler function for the given pattern
+// The pattern should start with the handler prefix, e.g. /ui/hello
+// If the pattern does not start with the handler prefix, it will be prepended with the handler prefix
+func (p *PluginUiRouter) HandleFunc(pattern string, handler func(http.ResponseWriter, *http.Request), mux *http.ServeMux) {
+	// If mux is nil, use the default ServeMux
+	if mux == nil {
+		mux = http.DefaultServeMux
+	}
+
+	// Make sure the pattern starts with the handler prefix
+	if !strings.HasPrefix(pattern, p.HandlerPrefix) {
+		pattern = p.HandlerPrefix + pattern
+	}
+
+	// Register the handler with the http.ServeMux
+	mux.HandleFunc(pattern, handler)
+}
+
+// Attach the embed UI handler to the target http.ServeMux
+func (p *PluginUiRouter) AttachHandlerToMux(mux *http.ServeMux) {
+	if mux == nil {
+		mux = http.DefaultServeMux
+	}
+
+	p.HandlerPrefix = strings.TrimSuffix(p.HandlerPrefix, "/")
+	mux.Handle(p.HandlerPrefix+"/", p.Handler())
+}

--- a/example/plugins/prometheus-exporter/mod/zoraxy_plugin/events/events.go
+++ b/example/plugins/prometheus-exporter/mod/zoraxy_plugin/events/events.go
@@ -1,0 +1,181 @@
+package events
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// EventName represents the type of event
+type EventName string
+
+// EventPayload interface for all event payloads
+type EventPayload interface {
+	// GetName returns the event type
+	GetName() EventName
+
+	// Returns the "source" of the event, that is, the component or plugin that emitted the event
+	GetEventSource() string
+}
+
+// Event represents a system event
+type Event struct {
+	Name      EventName    `json:"name"`
+	Timestamp int64        `json:"timestamp"` // Unix timestamp
+	UUID      string       `json:"uuid"`      // UUID for the event
+	Data      EventPayload `json:"data"`
+}
+
+const (
+	// EventBlacklistedIPBlocked is emitted when a blacklisted IP is blocked
+	EventBlacklistedIPBlocked EventName = "blacklistedIpBlocked"
+	// EventBlacklistToggled is emitted when the blacklist is toggled for an access rule
+	EventBlacklistToggled EventName = "blacklistToggled"
+	// EventAccessRuleCreated is emitted when a new access ruleset is created
+	EventAccessRuleCreated EventName = "accessRuleCreated"
+	// A custom event emitted by a plugin, with the intention of being broadcast
+	// to the designated recipient(s)
+	EventCustom EventName = "customEvent"
+	// A dummy event to satisfy the requirement of having at least one event
+	EventDummy EventName = "dummy"
+
+	// Add more event types as needed
+)
+
+var validEventNames = map[EventName]bool{
+	EventBlacklistedIPBlocked: true,
+	EventBlacklistToggled:     true,
+	EventAccessRuleCreated:    true,
+	EventCustom:               true,
+	EventDummy:                true,
+	// Add more event types as needed
+	// NOTE: Keep up-to-date with event names specified above
+}
+
+// Check if the event name is valid
+func (name EventName) IsValid() bool {
+	return validEventNames[name]
+}
+
+// BlacklistedIPBlockedEvent represents an event when a blacklisted IP is blocked
+type BlacklistedIPBlockedEvent struct {
+	IP           string `json:"ip"`
+	Comment      string `json:"comment"`
+	RequestedURL string `json:"requested_url"`
+	Hostname     string `json:"hostname"`
+	UserAgent    string `json:"user_agent"`
+	Method       string `json:"method"`
+}
+
+func (e *BlacklistedIPBlockedEvent) GetName() EventName {
+	return EventBlacklistedIPBlocked
+}
+
+func (e *BlacklistedIPBlockedEvent) GetEventSource() string {
+	return "proxy-access"
+}
+
+// BlacklistToggledEvent represents an event when the blacklist is disabled for an access rule
+type BlacklistToggledEvent struct {
+	RuleID  string `json:"rule_id"`
+	Enabled bool   `json:"enabled"` // Whether the blacklist is enabled or disabled
+}
+
+func (e *BlacklistToggledEvent) GetName() EventName {
+	return EventBlacklistToggled
+}
+
+func (e *BlacklistToggledEvent) GetEventSource() string {
+	return "accesslist-api"
+}
+
+// AccessRuleCreatedEvent represents an event when a new access ruleset is created
+type AccessRuleCreatedEvent struct {
+	ID               string `json:"id"`
+	Name             string `json:"name"`
+	Desc             string `json:"desc"`
+	BlacklistEnabled bool   `json:"blacklist_enabled"`
+	WhitelistEnabled bool   `json:"whitelist_enabled"`
+}
+
+func (e *AccessRuleCreatedEvent) GetName() EventName {
+	return EventAccessRuleCreated
+}
+
+func (e *AccessRuleCreatedEvent) GetEventSource() string {
+	return "accesslist-api"
+}
+
+type CustomEvent struct {
+	SourcePlugin string         `json:"source_plugin"`
+	Recipients   []string       `json:"recipients"`
+	Payload      map[string]any `json:"payload"`
+}
+
+func (e *CustomEvent) GetName() EventName {
+	return EventCustom
+}
+
+func (e *CustomEvent) GetEventSource() string {
+	return e.SourcePlugin
+}
+
+// ParseEvent parses a JSON byte slice into an Event struct
+func ParseEvent(jsonData []byte, event *Event) error {
+	// First, determine the event type, and parse shared fields, from the JSON data
+	var temp struct {
+		Name      EventName `json:"name"`
+		Timestamp int64     `json:"timestamp"`
+		UUID      string    `json:"uuid"`
+	}
+	if err := json.Unmarshal(jsonData, &temp); err != nil {
+		return err
+	}
+
+	// Set the event name and timestamp
+	event.Name = temp.Name
+	event.Timestamp = temp.Timestamp
+	event.UUID = temp.UUID
+
+	// Now, based on the event type, unmarshal the specific payload
+	switch temp.Name {
+	case EventBlacklistedIPBlocked:
+		type tempData struct {
+			Data BlacklistedIPBlockedEvent `json:"data"`
+		}
+		var payload tempData
+		if err := json.Unmarshal(jsonData, &payload); err != nil {
+			return err
+		}
+		event.Data = &payload.Data
+	case EventBlacklistToggled:
+		type tempData struct {
+			Data BlacklistToggledEvent `json:"data"`
+		}
+		var payload tempData
+		if err := json.Unmarshal(jsonData, &payload); err != nil {
+			return err
+		}
+		event.Data = &payload.Data
+	case EventAccessRuleCreated:
+		type tempData struct {
+			Data AccessRuleCreatedEvent `json:"data"`
+		}
+		var payload tempData
+		if err := json.Unmarshal(jsonData, &payload); err != nil {
+			return err
+		}
+		event.Data = &payload.Data
+	case EventCustom:
+		type tempData struct {
+			Data CustomEvent `json:"data"`
+		}
+		var payload tempData
+		if err := json.Unmarshal(jsonData, &payload); err != nil {
+			return err
+		}
+		event.Data = &payload.Data
+	default:
+		return fmt.Errorf("unknown event: %s, %v", temp.Name, jsonData)
+	}
+	return nil
+}

--- a/example/plugins/prometheus-exporter/mod/zoraxy_plugin/static_router.go
+++ b/example/plugins/prometheus-exporter/mod/zoraxy_plugin/static_router.go
@@ -1,0 +1,105 @@
+package zoraxy_plugin
+
+import (
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+)
+
+type PathRouter struct {
+	enableDebugPrint bool
+	pathHandlers     map[string]http.Handler
+	defaultHandler   http.Handler
+}
+
+// NewPathRouter creates a new PathRouter
+func NewPathRouter() *PathRouter {
+	return &PathRouter{
+		enableDebugPrint: false,
+		pathHandlers:     make(map[string]http.Handler),
+	}
+}
+
+// RegisterPathHandler registers a handler for a path
+func (p *PathRouter) RegisterPathHandler(path string, handler http.Handler) {
+	path = strings.TrimSuffix(path, "/")
+	p.pathHandlers[path] = handler
+}
+
+// RemovePathHandler removes a handler for a path
+func (p *PathRouter) RemovePathHandler(path string) {
+	delete(p.pathHandlers, path)
+}
+
+// SetDefaultHandler sets the default handler for the router
+// This handler will be called if no path handler is found
+func (p *PathRouter) SetDefaultHandler(handler http.Handler) {
+	p.defaultHandler = handler
+}
+
+// SetDebugPrintMode sets the debug print mode
+func (p *PathRouter) SetDebugPrintMode(enable bool) {
+	p.enableDebugPrint = enable
+}
+
+// StartStaticCapture starts the static capture ingress
+func (p *PathRouter) RegisterStaticCaptureHandle(capture_ingress string, mux *http.ServeMux) {
+	if !strings.HasSuffix(capture_ingress, "/") {
+		capture_ingress = capture_ingress + "/"
+	}
+	mux.Handle(capture_ingress, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		p.staticCaptureServeHTTP(w, r)
+	}))
+}
+
+// staticCaptureServeHTTP serves the static capture path using user defined handler
+func (p *PathRouter) staticCaptureServeHTTP(w http.ResponseWriter, r *http.Request) {
+	capturePath := r.Header.Get("X-Zoraxy-Capture")
+	if capturePath != "" {
+		if p.enableDebugPrint {
+			fmt.Printf("Using capture path: %s\n", capturePath)
+		}
+		originalURI := r.Header.Get("X-Zoraxy-Uri")
+		r.URL.Path = originalURI
+		if handler, ok := p.pathHandlers[capturePath]; ok {
+			handler.ServeHTTP(w, r)
+			return
+		}
+	}
+	p.defaultHandler.ServeHTTP(w, r)
+}
+
+func (p *PathRouter) PrintRequestDebugMessage(r *http.Request) {
+	if p.enableDebugPrint {
+		fmt.Printf("Capture Request with path: %s \n\n**Request Headers** \n\n", r.URL.Path)
+		keys := make([]string, 0, len(r.Header))
+		for key := range r.Header {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			for _, value := range r.Header[key] {
+				fmt.Printf("%s: %s\n", key, value)
+			}
+		}
+
+		fmt.Printf("\n\n**Request Details**\n\n")
+		fmt.Printf("Method: %s\n", r.Method)
+		fmt.Printf("URL: %s\n", r.URL.String())
+		fmt.Printf("Proto: %s\n", r.Proto)
+		fmt.Printf("Host: %s\n", r.Host)
+		fmt.Printf("RemoteAddr: %s\n", r.RemoteAddr)
+		fmt.Printf("RequestURI: %s\n", r.RequestURI)
+		fmt.Printf("ContentLength: %d\n", r.ContentLength)
+		fmt.Printf("TransferEncoding: %v\n", r.TransferEncoding)
+		fmt.Printf("Close: %v\n", r.Close)
+		fmt.Printf("Form: %v\n", r.Form)
+		fmt.Printf("PostForm: %v\n", r.PostForm)
+		fmt.Printf("MultipartForm: %v\n", r.MultipartForm)
+		fmt.Printf("Trailer: %v\n", r.Trailer)
+		fmt.Printf("RemoteAddr: %s\n", r.RemoteAddr)
+		fmt.Printf("RequestURI: %s\n", r.RequestURI)
+
+	}
+}

--- a/example/plugins/prometheus-exporter/mod/zoraxy_plugin/zoraxy_plugin.go
+++ b/example/plugins/prometheus-exporter/mod/zoraxy_plugin/zoraxy_plugin.go
@@ -1,0 +1,187 @@
+package zoraxy_plugin
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+)
+
+/*
+	Plugins Includes.go
+
+	This file is copied from Zoraxy source code
+	You can always find the latest version under mod/plugins/includes.go
+	Usually this file are backward compatible
+*/
+
+type PluginType int
+
+const (
+	PluginType_Router    PluginType = 0 //Router Plugin, used for handling / routing / forwarding traffic
+	PluginType_Utilities PluginType = 1 //Utilities Plugin, used for utilities like Zerotier or Static Web Server that do not require interception with the dpcore
+)
+
+type StaticCaptureRule struct {
+	CapturePath string `json:"capture_path"`
+	//To be expanded
+}
+
+type ControlStatusCode int
+
+const (
+	ControlStatusCode_CAPTURED  ControlStatusCode = 280 //Traffic captured by plugin, ask Zoraxy not to process the traffic
+	ControlStatusCode_UNHANDLED ControlStatusCode = 284 //Traffic not handled by plugin, ask Zoraxy to process the traffic
+	ControlStatusCode_ERROR     ControlStatusCode = 580 //Error occurred while processing the traffic, ask Zoraxy to process the traffic and log the error
+)
+
+type SubscriptionEvent struct {
+	EventName   string `json:"event_name"`
+	EventSource string `json:"event_source"`
+	Payload     string `json:"payload"` //Payload of the event, can be empty
+}
+
+type RuntimeConstantValue struct {
+	ZoraxyVersion    string `json:"zoraxy_version"`
+	ZoraxyUUID       string `json:"zoraxy_uuid"`
+	DevelopmentBuild bool   `json:"development_build"` //Whether the Zoraxy is a development build or not
+}
+
+type PermittedAPIEndpoint struct {
+	Method   string `json:"method"`   //HTTP method for the API endpoint (e.g., GET, POST)
+	Endpoint string `json:"endpoint"` //The API endpoint that the plugin can access
+	Reason   string `json:"reason"`   //The reason why the plugin needs to access this endpoint
+}
+
+/*
+IntroSpect Payload
+
+When the plugin is initialized with -introspect flag,
+the plugin shell return this payload as JSON and exit
+*/
+type IntroSpect struct {
+	/* Plugin metadata */
+	ID            string     `json:"id"`             //Unique ID of your plugin, recommended using your own domain in reverse like com.yourdomain.pluginname
+	Name          string     `json:"name"`           //Name of your plugin
+	Author        string     `json:"author"`         //Author name of your plugin
+	AuthorContact string     `json:"author_contact"` //Author contact of your plugin, like email
+	Description   string     `json:"description"`    //Description of your plugin
+	URL           string     `json:"url"`            //URL of your plugin
+	Type          PluginType `json:"type"`           //Type of your plugin, Router(0) or Utilities(1)
+	VersionMajor  int        `json:"version_major"`  //Major version of your plugin
+	VersionMinor  int        `json:"version_minor"`  //Minor version of your plugin
+	VersionPatch  int        `json:"version_patch"`  //Patch version of your plugin
+
+	/*
+
+		Endpoint Settings
+
+	*/
+
+	/*
+		Static Capture Settings
+
+		Once plugin is enabled these rules always applies to the enabled HTTP Proxy rule
+		This is faster than dynamic capture, but less flexible
+	*/
+	StaticCapturePaths   []StaticCaptureRule `json:"static_capture_paths"`   //Static capture paths of your plugin, see Zoraxy documentation for more details
+	StaticCaptureIngress string              `json:"static_capture_ingress"` //Static capture ingress path of your plugin (e.g. /s_handler)
+
+	/*
+		Dynamic Capture Settings
+
+		Once plugin is enabled, these rules will be captured and forward to plugin sniff
+		if the plugin sniff returns 280, the traffic will be captured
+		otherwise, the traffic will be forwarded to the next plugin
+		This is slower than static capture, but more flexible
+	*/
+	DynamicCaptureSniff   string `json:"dynamic_capture_sniff"`   //Dynamic capture sniff path of your plugin (e.g. /d_sniff)
+	DynamicCaptureIngress string `json:"dynamic_capture_ingress"` //Dynamic capture ingress path of your plugin (e.g. /d_handler)
+
+	/* UI Path for your plugin */
+	UIPath string `json:"ui_path"` //UI path of your plugin (e.g. /ui), will proxy the whole subpath tree to Zoraxy Web UI as plugin UI
+
+	/* Subscriptions Settings */
+	SubscriptionPath    string            `json:"subscription_path"`    //Subscription event path of your plugin (e.g. /notifyme), a POST request with SubscriptionEvent as body will be sent to this path when the event is triggered
+	SubscriptionsEvents map[string]string `json:"subscriptions_events"` //Subscriptions events of your plugin, paired with comments describing how the event is used, see Zoraxy documentation for more details
+
+	/* API Access Control */
+	PermittedAPIEndpoints []PermittedAPIEndpoint `json:"permitted_api_endpoints"` //List of API endpoints this plugin can access, and a description of why the plugin needs to access this endpoint
+}
+
+/*
+ServeIntroSpect Function
+
+This function will check if the plugin is initialized with -introspect flag,
+if so, it will print the intro spect and exit
+
+Place this function at the beginning of your plugin main function
+*/
+func ServeIntroSpect(pluginSpect *IntroSpect) {
+	if len(os.Args) > 1 && os.Args[1] == "-introspect" {
+		//Print the intro spect and exit
+		jsonData, _ := json.MarshalIndent(pluginSpect, "", " ")
+		fmt.Println(string(jsonData))
+		os.Exit(0)
+	}
+}
+
+/*
+ConfigureSpec Payload
+
+Zoraxy will start your plugin with -configure flag,
+the plugin shell read this payload as JSON and configure itself
+by the supplied values like starting a web server at given port
+that listens to 127.0.0.1:port
+*/
+type ConfigureSpec struct {
+	Port         int                  `json:"port"`                  //Port to listen
+	RuntimeConst RuntimeConstantValue `json:"runtime_const"`         //Runtime constant values
+	APIKey       string               `json:"api_key,omitempty"`     //API key for accessing Zoraxy APIs, if the plugin has permitted endpoints
+	ZoraxyPort   int                  `json:"zoraxy_port,omitempty"` //The port that Zoraxy is running on, used for making API calls to Zoraxy
+	//To be expanded
+}
+
+/*
+RecvExecuteConfigureSpec Function
+
+This function will read the configure spec from Zoraxy
+and return the ConfigureSpec object
+
+Place this function after ServeIntroSpect function in your plugin main function
+*/
+func RecvConfigureSpec() (*ConfigureSpec, error) {
+	for i, arg := range os.Args {
+		if strings.HasPrefix(arg, "-configure=") {
+			var configSpec ConfigureSpec
+			if err := json.Unmarshal([]byte(arg[11:]), &configSpec); err != nil {
+				return nil, err
+			}
+			return &configSpec, nil
+		} else if arg == "-configure" {
+			var configSpec ConfigureSpec
+			var nextArg string
+			if len(os.Args) > i+1 {
+				nextArg = os.Args[i+1]
+				if err := json.Unmarshal([]byte(nextArg), &configSpec); err != nil {
+					return nil, err
+				}
+			} else {
+				return nil, fmt.Errorf("no port specified after -configure flag")
+			}
+			return &configSpec, nil
+		}
+	}
+	return nil, fmt.Errorf("no -configure flag found")
+}
+
+/*
+ServeAndRecvSpec Function
+
+This function will serve the intro spect and return the configure spec
+See the ServeIntroSpect and RecvConfigureSpec for more details
+*/
+func ServeAndRecvSpec(pluginSpect *IntroSpect) (*ConfigureSpec, error) {
+	ServeIntroSpect(pluginSpect)
+	return RecvConfigureSpec()
+}


### PR DESCRIPTION
## Summary

- Adds a new example plugin `prometheus-exporter` that exposes Zoraxy statistical analysis data as Prometheus metrics
- Polls `/plugin/api/stats/summary` and `/plugin/api/stats/netstat` every 30 seconds via the plugin API
- Serves metrics in Prometheus text format on a configurable port (default `0.0.0.0:9100`) so Prometheus can scrape from outside localhost
- Also exposes a simple status UI in the Zoraxy plugin panel showing the metrics endpoint URL and today's request counts

## Exposed metrics

| Metric | Type | Description |
|---|---|---|
| `zoraxy_requests_today_total` | gauge | Total requests today |
| `zoraxy_requests_today_valid` | gauge | Valid requests today |
| `zoraxy_requests_today_error` | gauge | Error requests today |
| `zoraxy_requests_by_forward_type{type=...}` | gauge | Requests by forward type |
| `zoraxy_requests_by_country{country=...}` | gauge | Requests by origin country |
| `zoraxy_requests_by_downstream{hostname=...}` | gauge | Requests by downstream hostname |
| `zoraxy_requests_by_upstream{hostname=...}` | gauge | Requests by upstream hostname |
| `zoraxy_network_rx_bits_total` | counter | Accumulated received bits |
| `zoraxy_network_tx_bits_total` | counter | Accumulated transmitted bits |
| `zoraxy_stats_last_update_unix` | gauge | Timestamp of last successful fetch |

High-cardinality fields (client IPs, URLs, user agents, referrers) are intentionally omitted to avoid label cardinality explosion in Prometheus.

## Usage

Build and place binary in `plugins/prometheus-exporter/prometheus-exporter`, then enable in the Zoraxy plugin manager. Configure Prometheus to scrape:

```yaml
- job_name: zoraxy
  static_configs:
    - targets: ['<host>:9100']
```

Use `-metrics-port=<N>` to change the metrics port.

## Test plan

- [ ] Plugin introspects correctly (`-introspect` flag returns valid JSON)
- [ ] Plugin starts and registers with Zoraxy
- [ ] `/metrics` endpoint returns valid Prometheus text format
- [ ] Stats update every 30 seconds
- [ ] UI panel shows correct status and metrics endpoint URL
- [ ] `-metrics-port` flag changes the listen port

🤖 Generated with [Claude Code](https://claude.com/claude-code)