### PR TITLE
fix: port80 listener toggle and default site routing on HTTP

### DIFF
--- a/src/mod/dynamicproxy/dynamicproxy.go
+++ b/src/mod/dynamicproxy/dynamicproxy.go
@@ -164,7 +164,7 @@ func (router *Router) StartProxyService() error {
 								conn.Close()
 							} else {
 								//Default behavior
-								http.NotFound(w, r)
+								router.mux.ServeHTTP(w, r)
 							}
 
 						}

--- a/src/reverseproxy.go
+++ b/src/reverseproxy.go
@@ -1566,7 +1566,7 @@ func HandleUpdatePort80Listener(w http.ResponseWriter, r *http.Request) {
 		switch enabled {
 		case "true":
 			//Check if port 80 is already used by other services
-			if netutils.CheckIfPortOccupied(80) {
+			if netutils.CheckIfPortOccupied(80) && !dynamicProxyRouter.GetPort80ListenerState() {
 				utils.SendErrorResponse(w, "Port 80 is already used by other services")
 				return
 			}


### PR DESCRIPTION
## Bug Fixes

### Bug 1: Port 80 listener toggle reports "already used" incorrectly
When Zoraxy itself holds port 80, the toggle to enable the HTTP 
listener is greyed out with "Port 80 is already used by other services".
The check now correctly ignores Zoraxy's own listener.

Fix: reverseproxy.go:1569
if netutils.CheckIfPortOccupied(80) && !dynamicProxyRouter.GetPort80ListenerState()

### Bug 2: Default Site ignored for unknown domains on port 80
When Force HTTPS is disabled, requests from unknown domains on port 80
always returned 404 NOT FOUND, ignoring the configured Default Site 
option (Static Web Server, Redirect, etc.).

Fix: mod/dynamicproxy/dynamicproxy.go:167
router.mux.ServeHTTP(w, r) instead of http.NotFound(w, r)

## Testing
- Enable HTTP listener on port 80 works even when Zoraxy holds port 80
- Unknown domains on port 80 correctly route to configured Default Site