### PR TITLE
fix(dynamicproxy): set ReadHeaderTimeout and IdleTimeout on main listeners

### DIFF
--- a/src/mod/dynamicproxy/dynamicproxy.go
+++ b/src/mod/dynamicproxy/dynamicproxy.go
@@ -113,6 +113,12 @@ func (router *Router) StartProxyService() error {
 			Addr:      ":" + strconv.Itoa(router.Option.Port),
 			Handler:   router.mux,
 			TLSConfig: config,
+			// ReadHeaderTimeout bounds the slowloris window without affecting
+			// long-lived bodies (uploads, SSE, streaming). IdleTimeout reaps
+			// idle keep-alive connections. ReadTimeout/WriteTimeout left at 0
+			// so legitimate long-running requests still work.
+			ReadHeaderTimeout: 10 * time.Second,
+			IdleTimeout:       120 * time.Second,
 		}
 		router.Running = true
 		if router.Option.Port != 80 && router.Option.ListenOnPort80 && !netutils.CheckIfPortOccupied(80) {
@@ -234,7 +240,13 @@ func (router *Router) StartProxyService() error {
 	} else {
 		//Serve with non TLS mode
 		router.tlsListener = nil
-		router.server = &http.Server{Addr: ":" + strconv.Itoa(router.Option.Port), Handler: router.mux}
+		router.server = &http.Server{
+			Addr:    ":" + strconv.Itoa(router.Option.Port),
+			Handler: router.mux,
+			// See TLS branch above for rationale.
+			ReadHeaderTimeout: 10 * time.Second,
+			IdleTimeout:       120 * time.Second,
+		}
 		router.Running = true
 		router.Option.Logger.PrintAndLog("dprouter", "Reverse proxy service started in the background (Plain HTTP mode)", nil)
 		go func() {


### PR DESCRIPTION
Hello,
I used Claude Code to track down this connection leak. I'm running Zoraxy with upwards of 4 million requests per day and a million unique IP's. Thanks.


The TLS and plain-HTTP main reverse-proxy http.Server instances were constructed with no timeouts at all, while the port-80 redirector and secondary alt-port listeners already had them. Any client (broken NAT, slowloris, Cloudflare worker that disconnects uncleanly) could hold a connection open indefinitely, parking a (*conn).serve goroutine plus its runtime_pollWait reader until the kernel TCP keepalive eventually reaped the socket — hours by default.

Observed in production: ~1994 of 2023 goroutines created by net/http, with a clear accumulation tail (hundreds of connections >10 min old) showing this isn't steady-state traffic but a connection leak.

Add only ReadHeaderTimeout (slowloris defense) and IdleTimeout (keep- alive reaper). ReadTimeout and WriteTimeout are deliberately left at their zero defaults so legitimate long-lived requests — large uploads, server-sent events, streaming responses, long polling — keep working.