### PR TITLE
Fix/statistic bounded maps

### DIFF
--- a/src/def.go
+++ b/src/def.go
@@ -84,6 +84,9 @@ var (
 	/* Logging Configuration Flags */
 	enableLog = flag.Bool("enablelog", true, "Enable system wide logging, set to false for writing log to STDOUT only")
 
+	/* Statistics Configuration Flags */
+	statsMaxEntriesPerMap = flag.Int("stats_max_entries", 0, "Cap per-dimension statistics maps at N entries; when the cap is exceeded the entries with the lowest request counts are dropped first (0 = unbounded, matches upstream behavior; recommended value when enabled: 20000)")
+
 	/* Default Configuration Flags */
 	defaultInboundPort          = flag.Int("default_inbound_port", 443, "Default web server listening port")
 	defaultEnableInboundTraffic = flag.Bool("default_inbound_enabled", true, "If web server is enabled by default")

--- a/src/def.go
+++ b/src/def.go
@@ -85,7 +85,7 @@ var (
 	enableLog = flag.Bool("enablelog", true, "Enable system wide logging, set to false for writing log to STDOUT only")
 
 	/* Statistics Configuration Flags */
-	statsMaxEntriesPerMap = flag.Int("stats_max_entries", 0, "Cap per-dimension statistics maps at N entries; when the cap is exceeded the entries with the lowest request counts are dropped first (0 = unbounded, matches upstream behavior; recommended value when enabled: 20000)")
+	statsMaxEntriesPerMap = flag.Int("stats_max_entries", 0, "Soft-cap per-dimension statistics maps at N entries; when exceeded the entries with the lowest request counts are dropped first (0 = unbounded; recommended value when enabled: 20000)")
 
 	/* Default Configuration Flags */
 	defaultInboundPort          = flag.Int("default_inbound_port", 443, "Default web server listening port")

--- a/src/mod/statistic/bounded.go
+++ b/src/mod/statistic/bounded.go
@@ -6,18 +6,18 @@ import (
 	"sync/atomic"
 )
 
-// maxEntriesPerStatMap is a soft cap on entries per per-dimension sync.Map in
-// DailySummary. When a map exceeds this cap, its lowest-count entries are
-// evicted down to ~90% of the cap. This bounds memory growth driven by
-// high-cardinality request inputs (many unique client IPs, varied
-// User-Agent/Referer strings, or many distinct URL paths) while preserving
-// the most frequently observed entries — the data the dashboards actually
-// surface.
+// The runtime cap comes from CollectorOption.MaxEntriesPerStatMap (driven by
+// the -stats_max_entries CLI flag). 0 disables the cap entirely and uses the
+// upstream Load → check → Store path (see unboundedIncr in statistic.go).
 //
-// TODO: expose as a configuration option (e.g. via router.Option or a CLI
-// flag) so operators running large-scale deployments can tune it. Hardcoded
-// for now to keep the change surface small.
-const maxEntriesPerStatMap = 20000
+// When enabled, the cap is a soft cap: a trim runs when a new-key insert pushes
+// the map past it, dropping the 10% of entries with the lowest request counts
+// to make room. This bounds memory growth driven by high-cardinality request
+// inputs (many unique client IPs, varied User-Agent/Referer strings, or many
+// distinct URL paths) while preserving the most frequently observed entries —
+// the data the dashboards actually surface.
+//
+// Recommended value when enabling: 20000 (~32MB worst case across all 8 maps).
 
 // boundedCounter is a sidecar to a *sync.Map[string]int that tracks its
 // logical size atomically and serializes trim (eviction) operations.

--- a/src/mod/statistic/bounded.go
+++ b/src/mod/statistic/bounded.go
@@ -107,6 +107,9 @@ func evictLeastFrequent(m *sync.Map, b *boundedCounter, capN int) {
 	})
 
 	target := capN * 9 / 10
+	if target < 1 {
+		target = 1
+	}
 	if len(entries) <= target {
 		// Range observed fewer entries than expected (concurrent deletes
 		// from another path, or the size counter overshot). Reconcile.

--- a/src/mod/statistic/bounded.go
+++ b/src/mod/statistic/bounded.go
@@ -1,0 +1,127 @@
+package statistic
+
+import (
+	"sort"
+	"sync"
+	"sync/atomic"
+)
+
+// maxEntriesPerStatMap is a soft cap on entries per per-dimension sync.Map in
+// DailySummary. When a map exceeds this cap, its lowest-count entries are
+// evicted down to ~90% of the cap. This bounds memory growth driven by
+// high-cardinality request inputs (many unique client IPs, varied
+// User-Agent/Referer strings, or many distinct URL paths) while preserving
+// the most frequently observed entries — the data the dashboards actually
+// surface.
+//
+// TODO: expose as a configuration option (e.g. via router.Option or a CLI
+// flag) so operators running large-scale deployments can tune it. Hardcoded
+// for now to keep the change surface small.
+const maxEntriesPerStatMap = 20000
+
+// boundedCounter is a sidecar to a *sync.Map[string]int that tracks its
+// logical size atomically and serializes trim (eviction) operations.
+type boundedCounter struct {
+	size   atomic.Int64
+	trimMu sync.Mutex
+}
+
+func newBoundedCounter(initialSize int) *boundedCounter {
+	b := &boundedCounter{}
+	b.size.Store(int64(initialSize))
+	return b
+}
+
+// boundedCounters is the per-DailySummary set of size sidecars, one per
+// sync.Map field in DailySummary.
+type boundedCounters struct {
+	ForwardTypes        *boundedCounter
+	RequestOrigin       *boundedCounter
+	RequestClientIp     *boundedCounter
+	Referer             *boundedCounter
+	UserAgent           *boundedCounter
+	RequestURL          *boundedCounter
+	DownstreamHostnames *boundedCounter
+	UpstreamHostnames   *boundedCounter
+}
+
+func newBoundedCounters() boundedCounters {
+	return boundedCounters{
+		ForwardTypes:        newBoundedCounter(0),
+		RequestOrigin:       newBoundedCounter(0),
+		RequestClientIp:     newBoundedCounter(0),
+		Referer:             newBoundedCounter(0),
+		UserAgent:           newBoundedCounter(0),
+		RequestURL:          newBoundedCounter(0),
+		DownstreamHostnames: newBoundedCounter(0),
+		UpstreamHostnames:   newBoundedCounter(0),
+	}
+}
+
+// boundedIncr increments the counter for key in m, applying a soft cap of
+// capN entries. New keys past the cap trigger a trim that drops the entries
+// with the lowest request counts down to ~90% of capN. Safe for concurrent use.
+func boundedIncr(m *sync.Map, b *boundedCounter, key string, capN int) {
+	// LoadOrStore atomically inserts {key: 1} if absent; otherwise returns
+	// the existing value. The new-key branch is race-free; the increment
+	// branch matches the pre-existing non-atomic Load+Store pattern in
+	// RecordRequest (fixing that read-modify-write race is out of scope).
+	actual, loaded := m.LoadOrStore(key, 1)
+	if loaded {
+		m.Store(key, actual.(int)+1)
+		return
+	}
+
+	newSize := b.size.Add(1)
+	if int(newSize) <= capN {
+		return
+	}
+
+	// Try to acquire the trim lock without blocking. If another goroutine
+	// is already trimming, our insert lands; the next over-cap insert will
+	// trigger a trim.
+	if !b.trimMu.TryLock() {
+		return
+	}
+	defer b.trimMu.Unlock()
+
+	// Re-check under lock — the other trimmer may have just finished.
+	if int(b.size.Load()) <= capN {
+		return
+	}
+	evictLeastFrequent(m, b, capN)
+}
+
+// evictLeastFrequent removes the entries in m with the lowest request counts
+// until ~90% of capN entries remain. Caller must hold b.trimMu.
+func evictLeastFrequent(m *sync.Map, b *boundedCounter, capN int) {
+	type entry struct {
+		key   string
+		count int
+	}
+
+	entries := make([]entry, 0, capN+capN/8)
+	m.Range(func(k, v interface{}) bool {
+		entries = append(entries, entry{key: k.(string), count: v.(int)})
+		return true
+	})
+
+	target := capN * 9 / 10
+	if len(entries) <= target {
+		// Range observed fewer entries than expected (concurrent deletes
+		// from another path, or the size counter overshot). Reconcile.
+		b.size.Store(int64(len(entries)))
+		return
+	}
+
+	// Ascending by count; evict the front (lowest-frequency) until target.
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].count < entries[j].count
+	})
+
+	evictCount := len(entries) - target
+	for i := 0; i < evictCount; i++ {
+		m.Delete(entries[i].key)
+	}
+	b.size.Add(-int64(evictCount))
+}

--- a/src/mod/statistic/bounded_internal_test.go
+++ b/src/mod/statistic/bounded_internal_test.go
@@ -1,0 +1,115 @@
+package statistic
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+func TestBoundedIncrCountsExistingKeys(t *testing.T) {
+	m := &sync.Map{}
+	b := newBoundedCounter(0)
+
+	for i := 0; i < 100; i++ {
+		boundedIncr(m, b, "hot", 1000)
+	}
+
+	v, ok := m.Load("hot")
+	if !ok {
+		t.Fatalf("key 'hot' should exist")
+	}
+	if v.(int) != 100 {
+		t.Fatalf("expected count 100, got %d", v)
+	}
+	if got := b.size.Load(); got != 1 {
+		t.Fatalf("expected size counter 1, got %d", got)
+	}
+}
+
+func TestBoundedIncrTrimsLowFrequencyEntries(t *testing.T) {
+	const capN = 100
+	const inserts = 1000
+
+	m := &sync.Map{}
+	b := newBoundedCounter(0)
+
+	// 10 "hot" keys hit many times each; 990 "cold" keys hit once.
+	for i := 0; i < 10; i++ {
+		key := fmt.Sprintf("hot-%d", i)
+		for j := 0; j < 50; j++ {
+			boundedIncr(m, b, key, capN)
+		}
+	}
+	for i := 0; i < inserts-10; i++ {
+		boundedIncr(m, b, fmt.Sprintf("cold-%d", i), capN)
+	}
+
+	// After all inserts, map must have been trimmed at least once.
+	// Size should be at the trim target (capN * 9/10 = 90) or below.
+	got := mapLen(m)
+	if got > capN {
+		t.Fatalf("map size %d exceeded cap %d after trimming", got, capN)
+	}
+
+	// All 10 hot keys must survive — they have the highest counts.
+	for i := 0; i < 10; i++ {
+		key := fmt.Sprintf("hot-%d", i)
+		if _, ok := m.Load(key); !ok {
+			t.Errorf("hot key %s was evicted; high-frequency entries should be preserved", key)
+		}
+	}
+
+	// Size counter and actual map size should agree (within a small slop).
+	if diff := abs(int(b.size.Load()) - got); diff > 0 {
+		t.Errorf("size counter %d disagrees with actual map size %d", b.size.Load(), got)
+	}
+}
+
+func TestBoundedIncrConcurrent(t *testing.T) {
+	const capN = 500
+	const writers = 16
+	const perWriter = 2000
+
+	m := &sync.Map{}
+	b := newBoundedCounter(0)
+
+	var wg sync.WaitGroup
+	var ctr atomic.Int64
+	wg.Add(writers)
+	for w := 0; w < writers; w++ {
+		go func(wid int) {
+			defer wg.Done()
+			for i := 0; i < perWriter; i++ {
+				k := fmt.Sprintf("w%d-k%d", wid, i)
+				boundedIncr(m, b, k, capN)
+				ctr.Add(1)
+			}
+		}(w)
+	}
+	wg.Wait()
+
+	// Soft cap — concurrent inserts may briefly overshoot while a trim is in
+	// flight. Allow some slop; the important invariant is that we're nowhere
+	// near the unbounded writers*perWriter = 32,000.
+	got := mapLen(m)
+	if got > capN+writers {
+		t.Fatalf("map size %d well above cap %d after %d concurrent inserts", got, capN, ctr.Load())
+	}
+}
+
+func mapLen(m *sync.Map) int {
+	n := 0
+	m.Range(func(_, _ interface{}) bool {
+		n++
+		return true
+	})
+	return n
+}
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}

--- a/src/mod/statistic/bounded_internal_test.go
+++ b/src/mod/statistic/bounded_internal_test.go
@@ -66,6 +66,50 @@ func TestBoundedIncrTrimsLowFrequencyEntries(t *testing.T) {
 	}
 }
 
+func TestNewIncrFnDispatch(t *testing.T) {
+	// maxEntries=0 selects the unbounded path (upstream behavior).
+	unbounded := newIncrFn(0)
+	m1 := &sync.Map{}
+	b1 := newBoundedCounter(0)
+	for i := 0; i < 50; i++ {
+		unbounded(m1, b1, fmt.Sprintf("k%d", i))
+	}
+	if got := mapLen(m1); got != 50 {
+		t.Errorf("unbounded path: expected 50 entries, got %d (cap should not apply)", got)
+	}
+	if got := b1.size.Load(); got != 0 {
+		t.Errorf("unbounded path: bounded counter should stay at 0, got %d", got)
+	}
+
+	// maxEntries>0 selects the bounded path.
+	bounded := newIncrFn(10)
+	m2 := &sync.Map{}
+	b2 := newBoundedCounter(0)
+	for i := 0; i < 100; i++ {
+		bounded(m2, b2, fmt.Sprintf("k%d", i))
+	}
+	if got := mapLen(m2); got > 10 {
+		t.Errorf("bounded path with cap=10: map size %d exceeds cap", got)
+	}
+}
+
+func TestUnboundedIncrMatchesUpstreamPattern(t *testing.T) {
+	// unboundedIncr must reproduce Load → check → Store exactly.
+	m := &sync.Map{}
+	unboundedIncr(m, nil, "new-key")
+	v, ok := m.Load("new-key")
+	if !ok || v.(int) != 1 {
+		t.Fatalf("first insert: expected count 1, got %v (ok=%v)", v, ok)
+	}
+	for i := 0; i < 9; i++ {
+		unboundedIncr(m, nil, "new-key")
+	}
+	v, _ = m.Load("new-key")
+	if v.(int) != 10 {
+		t.Fatalf("after 10 increments: expected count 10, got %v", v)
+	}
+}
+
 func TestBoundedIncrConcurrent(t *testing.T) {
 	const capN = 500
 	const writers = 16

--- a/src/mod/statistic/statistic.go
+++ b/src/mod/statistic/statistic.go
@@ -85,9 +85,9 @@ func newIncrFn(maxEntries int) incrFn {
 	if maxEntries <= 0 {
 		return unboundedIncr
 	}
-	cap := maxEntries
+	capN := maxEntries
 	return func(m *sync.Map, b *boundedCounter, key string) {
-		boundedIncr(m, b, key, cap)
+		boundedIncr(m, b, key, capN)
 	}
 }
 

--- a/src/mod/statistic/statistic.go
+++ b/src/mod/statistic/statistic.go
@@ -36,7 +36,7 @@ type DailySummary struct {
 	// bounded tracks the logical size of each map above and serializes
 	// the trim path so that high-cardinality request inputs (many unique
 	// IPs, UA/Referer strings, or URL paths) don't grow the maps without
-	// bound.
+	// bound when the cap is enabled.
 	bounded boundedCounters
 }
 
@@ -55,6 +55,13 @@ type RequestInfo struct {
 
 type CollectorOption struct {
 	Database *database.Database
+	// MaxEntriesPerStatMap is the per-dimension soft cap for the sync.Map
+	// fields in DailySummary. 0 means unbounded (matches upstream behavior
+	// byte-for-byte). A positive value enables a bounded mode where, when
+	// the cap is exceeded, the entries with the lowest request counts are
+	// dropped first (see mod/statistic/bounded.go). Recommended value when
+	// enabled: 20000 (≈32MB worst-case across all 8 maps).
+	MaxEntriesPerStatMap int
 }
 
 type Collector struct {
@@ -63,6 +70,37 @@ type Collector struct {
 	autSaveStop    chan bool
 	DailySummary   *DailySummary
 	Option         *CollectorOption
+	// incr is the per-request map-increment strategy, chosen once at startup
+	// based on Option.MaxEntriesPerStatMap. See newIncrFn.
+	incr incrFn
+}
+
+// incrFn is the dispatch shape for "increment one entry in one of the eight
+// per-dimension sync.Maps". Either unboundedIncr (the upstream behavior, no
+// cap) or a closure over boundedIncr (capped at a fixed entry count, with
+// the lowest-frequency entries dropped first when the cap is exceeded).
+type incrFn func(m *sync.Map, b *boundedCounter, key string)
+
+func newIncrFn(maxEntries int) incrFn {
+	if maxEntries <= 0 {
+		return unboundedIncr
+	}
+	cap := maxEntries
+	return func(m *sync.Map, b *boundedCounter, key string) {
+		boundedIncr(m, b, key, cap)
+	}
+}
+
+// unboundedIncr reproduces the maintainer's original Load → check → Store
+// pattern verbatim. The bounded-counter sidecar parameter is ignored.
+// Selected when CollectorOption.MaxEntriesPerStatMap == 0 (the default).
+func unboundedIncr(m *sync.Map, _ *boundedCounter, key string) {
+	v, ok := m.Load(key)
+	if !ok {
+		m.Store(key, 1)
+	} else {
+		m.Store(key, v.(int)+1)
+	}
 }
 
 func NewStatisticCollector(option CollectorOption) (*Collector, error) {
@@ -72,6 +110,7 @@ func NewStatisticCollector(option CollectorOption) (*Collector, error) {
 	thisCollector := Collector{
 		DailySummary: NewDailySummary(),
 		Option:       &option,
+		incr:         newIncrFn(option.MaxEntriesPerStatMap),
 	}
 
 	//Load the stat if exists for today
@@ -176,14 +215,15 @@ func (c *Collector) RecordRequest(ri RequestInfo) {
 			c.DailySummary.ErrorRequest++
 		}
 
-		//Store the request info into correct types of maps. boundedIncr
-		//caps each map at maxEntriesPerStatMap entries (lowest-count
-		//entries are dropped first when the cap is exceeded) to bound
-		//memory growth under high-cardinality input.
-		boundedIncr(c.DailySummary.ForwardTypes, c.DailySummary.bounded.ForwardTypes, ri.ForwardType, maxEntriesPerStatMap)
+		//Store the request info into correct types of maps. c.incr is
+		//either the original upstream Load/Store pattern (unbounded) or
+		//a capped variant that drops the lowest-count entries when
+		//full. Selected once at startup based on the -stats_max_entries
+		//flag (default 0 = unbounded).
+		c.incr(c.DailySummary.ForwardTypes, c.DailySummary.bounded.ForwardTypes, ri.ForwardType)
 
 		originISO := strings.ToLower(ri.RequestOriginalCountryISOCode)
-		boundedIncr(c.DailySummary.RequestOrigin, c.DailySummary.bounded.RequestOrigin, originISO, maxEntriesPerStatMap)
+		c.incr(c.DailySummary.RequestOrigin, c.DailySummary.bounded.RequestOrigin, originISO)
 
 		//Filter out CF forwarded requests
 		if strings.Contains(ri.IpAddr, ",") {
@@ -195,17 +235,17 @@ func (c *Collector) RecordRequest(ri RequestInfo) {
 			}
 		}
 
-		boundedIncr(c.DailySummary.RequestClientIp, c.DailySummary.bounded.RequestClientIp, ri.IpAddr, maxEntriesPerStatMap)
+		c.incr(c.DailySummary.RequestClientIp, c.DailySummary.bounded.RequestClientIp, ri.IpAddr)
 
 		//Record the referer
 		p := bluemonday.StripTagsPolicy()
 		filteredReferer := p.Sanitize(
 			ri.Referer,
 		)
-		boundedIncr(c.DailySummary.Referer, c.DailySummary.bounded.Referer, filteredReferer, maxEntriesPerStatMap)
+		c.incr(c.DailySummary.Referer, c.DailySummary.bounded.Referer, filteredReferer)
 
 		//Record the UserAgent
-		boundedIncr(c.DailySummary.UserAgent, c.DailySummary.bounded.UserAgent, ri.UserAgent, maxEntriesPerStatMap)
+		c.incr(c.DailySummary.UserAgent, c.DailySummary.bounded.UserAgent, ri.UserAgent)
 
 		//Record request URL, if it is a page
 		ext := filepath.Ext(ri.RequestURL)
@@ -214,15 +254,15 @@ func (c *Collector) RecordRequest(ri RequestInfo) {
 			return
 		}
 
-		boundedIncr(c.DailySummary.RequestURL, c.DailySummary.bounded.RequestURL, ri.RequestURL, maxEntriesPerStatMap)
+		c.incr(c.DailySummary.RequestURL, c.DailySummary.bounded.RequestURL, ri.RequestURL)
 
 		//Record the downstream hostname
 		//This is the hostname that the user visited, not the target domain
-		boundedIncr(c.DailySummary.DownstreamHostnames, c.DailySummary.bounded.DownstreamHostnames, ri.Target, maxEntriesPerStatMap)
+		c.incr(c.DailySummary.DownstreamHostnames, c.DailySummary.bounded.DownstreamHostnames, ri.Target)
 
 		//Record the upstream hostname
 		//This is the selected load balancer upstream hostname or ip
-		boundedIncr(c.DailySummary.UpstreamHostnames, c.DailySummary.bounded.UpstreamHostnames, ri.Upstream, maxEntriesPerStatMap)
+		c.incr(c.DailySummary.UpstreamHostnames, c.DailySummary.bounded.UpstreamHostnames, ri.Upstream)
 	}()
 
 	//ADD MORE HERE IF NEEDED

--- a/src/mod/statistic/statistic.go
+++ b/src/mod/statistic/statistic.go
@@ -32,6 +32,12 @@ type DailySummary struct {
 	RequestURL          *sync.Map //Request URL of the request object
 	DownstreamHostnames *sync.Map //Request count of downstream hostname
 	UpstreamHostnames   *sync.Map //Forwarded request count of upstream hostname
+
+	// bounded tracks the logical size of each map above and serializes
+	// the trim path so that high-cardinality request inputs (many unique
+	// IPs, UA/Referer strings, or URL paths) don't grow the maps without
+	// bound.
+	bounded boundedCounters
 }
 
 type RequestInfo struct {
@@ -170,21 +176,14 @@ func (c *Collector) RecordRequest(ri RequestInfo) {
 			c.DailySummary.ErrorRequest++
 		}
 
-		//Store the request info into correct types of maps
-		ft, ok := c.DailySummary.ForwardTypes.Load(ri.ForwardType)
-		if !ok {
-			c.DailySummary.ForwardTypes.Store(ri.ForwardType, 1)
-		} else {
-			c.DailySummary.ForwardTypes.Store(ri.ForwardType, ft.(int)+1)
-		}
+		//Store the request info into correct types of maps. boundedIncr
+		//caps each map at maxEntriesPerStatMap entries (lowest-count
+		//entries are dropped first when the cap is exceeded) to bound
+		//memory growth under high-cardinality input.
+		boundedIncr(c.DailySummary.ForwardTypes, c.DailySummary.bounded.ForwardTypes, ri.ForwardType, maxEntriesPerStatMap)
 
 		originISO := strings.ToLower(ri.RequestOriginalCountryISOCode)
-		fo, ok := c.DailySummary.RequestOrigin.Load(originISO)
-		if !ok {
-			c.DailySummary.RequestOrigin.Store(originISO, 1)
-		} else {
-			c.DailySummary.RequestOrigin.Store(originISO, fo.(int)+1)
-		}
+		boundedIncr(c.DailySummary.RequestOrigin, c.DailySummary.bounded.RequestOrigin, originISO, maxEntriesPerStatMap)
 
 		//Filter out CF forwarded requests
 		if strings.Contains(ri.IpAddr, ",") {
@@ -196,32 +195,17 @@ func (c *Collector) RecordRequest(ri RequestInfo) {
 			}
 		}
 
-		fi, ok := c.DailySummary.RequestClientIp.Load(ri.IpAddr)
-		if !ok {
-			c.DailySummary.RequestClientIp.Store(ri.IpAddr, 1)
-		} else {
-			c.DailySummary.RequestClientIp.Store(ri.IpAddr, fi.(int)+1)
-		}
+		boundedIncr(c.DailySummary.RequestClientIp, c.DailySummary.bounded.RequestClientIp, ri.IpAddr, maxEntriesPerStatMap)
 
 		//Record the referer
 		p := bluemonday.StripTagsPolicy()
 		filteredReferer := p.Sanitize(
 			ri.Referer,
 		)
-		rf, ok := c.DailySummary.Referer.Load(filteredReferer)
-		if !ok {
-			c.DailySummary.Referer.Store(filteredReferer, 1)
-		} else {
-			c.DailySummary.Referer.Store(filteredReferer, rf.(int)+1)
-		}
+		boundedIncr(c.DailySummary.Referer, c.DailySummary.bounded.Referer, filteredReferer, maxEntriesPerStatMap)
 
 		//Record the UserAgent
-		ua, ok := c.DailySummary.UserAgent.Load(ri.UserAgent)
-		if !ok {
-			c.DailySummary.UserAgent.Store(ri.UserAgent, 1)
-		} else {
-			c.DailySummary.UserAgent.Store(ri.UserAgent, ua.(int)+1)
-		}
+		boundedIncr(c.DailySummary.UserAgent, c.DailySummary.bounded.UserAgent, ri.UserAgent, maxEntriesPerStatMap)
 
 		//Record request URL, if it is a page
 		ext := filepath.Ext(ri.RequestURL)
@@ -230,30 +214,15 @@ func (c *Collector) RecordRequest(ri RequestInfo) {
 			return
 		}
 
-		ru, ok := c.DailySummary.RequestURL.Load(ri.RequestURL)
-		if !ok {
-			c.DailySummary.RequestURL.Store(ri.RequestURL, 1)
-		} else {
-			c.DailySummary.RequestURL.Store(ri.RequestURL, ru.(int)+1)
-		}
+		boundedIncr(c.DailySummary.RequestURL, c.DailySummary.bounded.RequestURL, ri.RequestURL, maxEntriesPerStatMap)
 
 		//Record the downstream hostname
 		//This is the hostname that the user visited, not the target domain
-		ds, ok := c.DailySummary.DownstreamHostnames.Load(ri.Target)
-		if !ok {
-			c.DailySummary.DownstreamHostnames.Store(ri.Target, 1)
-		} else {
-			c.DailySummary.DownstreamHostnames.Store(ri.Target, ds.(int)+1)
-		}
+		boundedIncr(c.DailySummary.DownstreamHostnames, c.DailySummary.bounded.DownstreamHostnames, ri.Target, maxEntriesPerStatMap)
 
 		//Record the upstream hostname
 		//This is the selected load balancer upstream hostname or ip
-		us, ok := c.DailySummary.UpstreamHostnames.Load(ri.Upstream)
-		if !ok {
-			c.DailySummary.UpstreamHostnames.Store(ri.Upstream, 1)
-		} else {
-			c.DailySummary.UpstreamHostnames.Store(ri.Upstream, us.(int)+1)
-		}
+		boundedIncr(c.DailySummary.UpstreamHostnames, c.DailySummary.bounded.UpstreamHostnames, ri.Upstream, maxEntriesPerStatMap)
 	}()
 
 	//ADD MORE HERE IF NEEDED
@@ -303,6 +272,7 @@ func NewDailySummary() *DailySummary {
 		RequestURL:          &sync.Map{},
 		DownstreamHostnames: &sync.Map{},
 		UpstreamHostnames:   &sync.Map{},
+		bounded:             newBoundedCounters(),
 	}
 }
 

--- a/src/mod/statistic/structconv.go
+++ b/src/mod/statistic/structconv.go
@@ -70,24 +70,25 @@ func DailySummaryExportToSummary(export DailySummaryExport) DailySummary {
 		TotalRequest:        export.TotalRequest,
 		ErrorRequest:        export.ErrorRequest,
 		ValidRequest:        export.ValidRequest,
-		ForwardTypes:        &sync.Map{},
-		RequestOrigin:       &sync.Map{},
-		RequestClientIp:     &sync.Map{},
-		Referer:             &sync.Map{},
-		UserAgent:           &sync.Map{},
-		RequestURL:          &sync.Map{},
-		DownstreamHostnames: &sync.Map{},
-		UpstreamHostnames:   &sync.Map{},
+		ForwardTypes:        MapStringIntToSyncMap(export.ForwardTypes),
+		RequestOrigin:       MapStringIntToSyncMap(export.RequestOrigin),
+		RequestClientIp:     MapStringIntToSyncMap(export.RequestClientIp),
+		Referer:             MapStringIntToSyncMap(export.Referer),
+		UserAgent:           MapStringIntToSyncMap(export.UserAgent),
+		RequestURL:          MapStringIntToSyncMap(export.RequestURL),
+		DownstreamHostnames: MapStringIntToSyncMap(export.Downstreams),
+		UpstreamHostnames:   MapStringIntToSyncMap(export.Upstreams),
+		bounded: boundedCounters{
+			ForwardTypes:        newBoundedCounter(len(export.ForwardTypes)),
+			RequestOrigin:       newBoundedCounter(len(export.RequestOrigin)),
+			RequestClientIp:     newBoundedCounter(len(export.RequestClientIp)),
+			Referer:             newBoundedCounter(len(export.Referer)),
+			UserAgent:           newBoundedCounter(len(export.UserAgent)),
+			RequestURL:          newBoundedCounter(len(export.RequestURL)),
+			DownstreamHostnames: newBoundedCounter(len(export.Downstreams)),
+			UpstreamHostnames:   newBoundedCounter(len(export.Upstreams)),
+		},
 	}
-
-	summary.ForwardTypes = MapStringIntToSyncMap(export.ForwardTypes)
-	summary.RequestOrigin = MapStringIntToSyncMap(export.RequestOrigin)
-	summary.RequestClientIp = MapStringIntToSyncMap(export.RequestClientIp)
-	summary.Referer = MapStringIntToSyncMap(export.Referer)
-	summary.UserAgent = MapStringIntToSyncMap(export.UserAgent)
-	summary.RequestURL = MapStringIntToSyncMap(export.RequestURL)
-	summary.DownstreamHostnames = MapStringIntToSyncMap(export.Downstreams)
-	summary.UpstreamHostnames = MapStringIntToSyncMap(export.Upstreams)
 
 	return summary
 }

--- a/src/start.go
+++ b/src/start.go
@@ -195,7 +195,8 @@ func startupSequence() {
 
 	//Create a statistic collector
 	statisticCollector, err = statistic.NewStatisticCollector(statistic.CollectorOption{
-		Database: sysdb,
+		Database:             sysdb,
+		MaxEntriesPerStatMap: *statsMaxEntriesPerMap,
 	})
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Hello,
I fixed an unbounded growth bug in the statistics module with help from Claude.

"per-day statistics maps grow without bound under high-cardinality request inputs, leading to OOM-kill"

Memory usage will grow throughout the day, eventually leading to an out of memory process kill.

I'm getting millions of requests per day from many hundreds of thousands unique ip's.

The attached screenshot from the Resource Monitor plugin shows memory growing steadily before the patch, and a flat line after the patch. I'm running with -fastgeoip otherwise the cpu would be pegged.
<img width="1425" height="503" alt="Screenshot 2026-05-23 at 08 31 20" src="https://github.com/user-attachments/assets/0de71f64-9a9e-470b-a267-99f218fcdfee" />

Before the patch, sys.db would grow 800mb+ per 24 hours and I was having to delete it at midnight and start over.
After the patch, sys.db grows much slower. Only about 160mb after 4-5 days, because there are fewer items saved to the db. I've tested -stats_max_entries with 20000, 50000, and 100000, and the memory usage has consistently stayed flat. Sys.db growth scaled with the -stats_max_entries cap, as expected.





By Claude:
In mod/statistic, the per-day DailySummary keeps a separate map for each request dimension it tracks — client IP, User-Agent, Referer, request URL, downstream and upstream hostnames, and forwarding type. Each map grows by one entry per distinct value seen, and the maps reset at midnight. For the four dimensions whose values come straight from the request stream (client IP, User-Agent, Referer, URL), the set of possible values is effectively unbounded — every distinct value lands as a new permanent map entry until the next reset. On a busy proxy this can drive memory consumption well into the gigabytes over a day of uptime, amplified by the autosave path which re-serializes the whole summary to disk every ten minutes. A handful of past issues have reported Zoraxy gradually consuming all available memory across multi-day cycles (most notably #1007 and parts of the discussion on #816); the existing -fastgeoip workaround addresses a different startup-time allocation and doesn't help with this runtime growth.

This patch adds a per-map size cap that's opt-in via a new CLI flag, -stats_max_entries=N. When unset (or =0), behavior is byte-for-byte identical to the current code — same Load → check → Store pattern, no overhead, no risk to existing deployments. When set to a positive value, each of the eight maps stays at or under N entries. Once a map fills up, the next new insert triggers a quick trim: it scans the map, sorts entries by how many requests they've received, and drops the lowest-count 10% to make room. Existing entries continue to count up at the same speed they always did; the trim only runs on the relatively rare event of a new entry arriving at a full map, and trims that happen at the same time are serialized so request handling never blocks on stat collection.

The choice to drop the lowest-count entries (rather than oldest, newest, or random) means the data the dashboards actually display is preserved. The top-IPs, top-User-Agents, top-URLs panels all surface the most-frequently-seen items in each dimension — and those are exactly the entries the cap keeps. What gets dropped is the long tail: a single visit from an unusual IP, a malformed Referer, a one-time URL request. None of those would have shown up on the dashboard anyway. The top-line totals (TotalRequest / ValidRequest / ErrorRequest) are completely untouched, so the "X requests today" headline remains exact regardless of the cap. Recommended starting value is -stats_max_entries=20000, which gives plenty of headroom for legitimate diversity while bounding the stats structure at roughly 32 MB worst case across all eight maps.


****