### PR TITLE
feat: per-route OAuth2 provider + auth exception rules for all auth m…

### DIFF
--- a/src/mod/auth/sso/oauth2/oauth2.go
+++ b/src/mod/auth/sso/oauth2/oauth2.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/jellydator/ttlcache/v3"
@@ -53,8 +54,23 @@ type OIDCDiscoveryDocument struct {
 	UserinfoEndpoint                  string   `json:"userinfo_endpoint"`
 }
 
+// OAuth2ProviderConfig holds per-route OAuth2 provider configuration.
+// Non-empty fields override the global OAuth2 router settings for a specific route.
+// Assign this to AuthenticationProvider.OAuth2Config on a ProxyEndpoint to use
+// a dedicated OAuth2 application (e.g. a different Authentik provider) for that route.
+type OAuth2ProviderConfig struct {
+	OAuth2WellKnownUrl string // OIDC discovery URL, e.g. https://auth.example.com/app/.well-known/openid-configuration
+	OAuth2ServerURL    string // Authorization endpoint (used when WellKnown is not set)
+	OAuth2TokenURL     string // Token endpoint (used when WellKnown is not set)
+	OAuth2UserInfoUrl  string // Userinfo endpoint (optional, discovered from WellKnown if empty)
+	OAuth2ClientId     string // Client ID for this route
+	OAuth2ClientSecret string // Client Secret for this route
+	OAuth2Scopes       string // Comma-separated scopes (optional, overrides global)
+}
+
 type OAuth2Router struct {
-	options *OAuth2RouterOptions
+	options          *OAuth2RouterOptions
+	userInfoUrlCache sync.Map // map[cacheKey string]string — resolved userInfoUrl per cache entry
 }
 
 // NewOAuth2Router creates a new OAuth2Router object
@@ -230,39 +246,56 @@ func (ar *OAuth2Router) handleSetOAuthSettingsDELETE(w http.ResponseWriter, r *h
 	utils.SendOK(w)
 }
 
+// fetchOAuth2ConfigurationFromURL fetches the OIDC discovery document from the given wellKnownUrl
+// and populates missing fields in config. Returns the updated config and the resolved userInfoUrl.
+// Unlike the old fetchOAuth2Configuration, this does NOT modify ar.options (no global side-effects).
+func (ar *OAuth2Router) fetchOAuth2ConfigurationFromURL(config *oauth2.Config, wellKnownUrl string, existingUserInfoUrl string) (*oauth2.Config, string, error) {
+	req, err := http.NewRequest("GET", wellKnownUrl, nil)
+	if err != nil {
+		return nil, existingUserInfoUrl, err
+	}
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, existingUserInfoUrl, err
+	}
+	defer resp.Body.Close()
+
+	oidcDiscoveryDocument := OIDCDiscoveryDocument{}
+	if err := json.NewDecoder(resp.Body).Decode(&oidcDiscoveryDocument); err != nil {
+		ar.options.Logger.PrintAndLog("OAuth2Router", fmt.Sprintf("Failed to decode ([%d] %s)", resp.StatusCode, resp.Status), err)
+		return nil, existingUserInfoUrl, err
+	}
+
+	if len(config.Scopes) == 0 {
+		config.Scopes = oidcDiscoveryDocument.ScopesSupported
+	}
+	if config.Endpoint.AuthURL == "" {
+		config.Endpoint.AuthURL = oidcDiscoveryDocument.AuthorizationEndpoint
+	}
+	if config.Endpoint.TokenURL == "" {
+		config.Endpoint.TokenURL = oidcDiscoveryDocument.TokenEndpoint
+	}
+
+	resolvedUserInfoUrl := existingUserInfoUrl
+	if resolvedUserInfoUrl == "" {
+		resolvedUserInfoUrl = oidcDiscoveryDocument.UserinfoEndpoint
+	}
+
+	return config, resolvedUserInfoUrl, nil
+}
+
+// fetchOAuth2Configuration is kept for backward compatibility with the global config path.
 func (ar *OAuth2Router) fetchOAuth2Configuration(config *oauth2.Config) (*oauth2.Config, error) {
-	req, err := http.NewRequest("GET", ar.options.OAuth2WellKnownUrl, nil)
+	updated, userInfoUrl, err := ar.fetchOAuth2ConfigurationFromURL(config, ar.options.OAuth2WellKnownUrl, ar.options.OAuth2UserInfoUrl)
 	if err != nil {
 		return nil, err
 	}
-	client := &http.Client{}
-	if resp, err := client.Do(req); err != nil {
-		return nil, err
-	} else {
-		defer resp.Body.Close()
-		oidcDiscoveryDocument := OIDCDiscoveryDocument{}
-		if err := json.NewDecoder(resp.Body).Decode(&oidcDiscoveryDocument); err != nil {
-			ar.options.Logger.PrintAndLog("OAuth2Router", fmt.Sprintf("Failed to decode ([%d] %s)", resp.StatusCode, resp.Status), err)
-			return nil, err
-		}
-		if len(config.Scopes) == 0 {
-			config.Scopes = oidcDiscoveryDocument.ScopesSupported
-		}
-
-		if config.Endpoint.AuthURL == "" {
-			config.Endpoint.AuthURL = oidcDiscoveryDocument.AuthorizationEndpoint
-		}
-
-		if config.Endpoint.TokenURL == "" {
-			config.Endpoint.TokenURL = oidcDiscoveryDocument.TokenEndpoint
-		}
-
-		if ar.options.OAuth2UserInfoUrl == "" {
-			ar.options.OAuth2UserInfoUrl = oidcDiscoveryDocument.UserinfoEndpoint
-		}
-
+	// Update global options only for the global config path (backward compat)
+	if ar.options.OAuth2UserInfoUrl == "" {
+		ar.options.OAuth2UserInfoUrl = userInfoUrl
 	}
-	return config, nil
+	return updated, nil
 }
 
 func (ar *OAuth2Router) newOAuth2Conf(redirectUrl string) (*oauth2.Config, error) {
@@ -285,10 +318,87 @@ func (ar *OAuth2Router) newOAuth2Conf(redirectUrl string) (*oauth2.Config, error
 	return config, nil
 }
 
-// HandleOAuth2Auth is the internal handler for OAuth authentication
-// Set useHTTPS to true if your OAuth server is using HTTPS
-// Set OAuthURL to the URL of the OAuth server, e.g. OAuth.example.com
-func (ar *OAuth2Router) HandleOAuth2Auth(w http.ResponseWriter, r *http.Request) error {
+// newOAuth2ConfFromRouteConfig creates an OAuth2 config using effective (merged) settings.
+// Returns the config and the resolved userInfoUrl (discovered from well-known if necessary).
+func (ar *OAuth2Router) newOAuth2ConfFromRouteConfig(redirectUrl string, eff *effectiveOAuth2Config) (*oauth2.Config, string, error) {
+	config := &oauth2.Config{
+		ClientID:     eff.clientId,
+		ClientSecret: eff.clientSecret,
+		RedirectURL:  redirectUrl,
+		Endpoint: oauth2.Endpoint{
+			AuthURL:  eff.serverURL,
+			TokenURL: eff.tokenURL,
+		},
+	}
+	if eff.scopes != "" {
+		config.Scopes = strings.Split(eff.scopes, ",")
+	}
+	resolvedUserInfoUrl := eff.userInfoUrl
+	if eff.wellKnownUrl != "" && (config.Endpoint.AuthURL == "" || config.Endpoint.TokenURL == "" || resolvedUserInfoUrl == "") {
+		updated, resolved, err := ar.fetchOAuth2ConfigurationFromURL(config, eff.wellKnownUrl, resolvedUserInfoUrl)
+		if err != nil {
+			return nil, "", err
+		}
+		return updated, resolved, nil
+	}
+	return config, resolvedUserInfoUrl, nil
+}
+
+// effectiveOAuth2Config holds the resolved OAuth2 settings for a single request,
+// merging per-route overrides on top of global defaults.
+type effectiveOAuth2Config struct {
+	clientId    string
+	clientSecret string
+	wellKnownUrl string
+	serverURL   string
+	tokenURL    string
+	userInfoUrl string
+	scopes      string
+	cacheKey    string // unique key for the config cache
+}
+
+// resolveEffectiveConfig merges a per-route OAuth2ProviderConfig over the global options.
+// If routeConfig is nil or has no ClientId, the global config is used unchanged.
+func (ar *OAuth2Router) resolveEffectiveConfig(host string, routeConfig *OAuth2ProviderConfig) *effectiveOAuth2Config {
+	eff := &effectiveOAuth2Config{
+		clientId:     ar.options.OAuth2ClientId,
+		clientSecret: ar.options.OAuth2ClientSecret,
+		wellKnownUrl: ar.options.OAuth2WellKnownUrl,
+		serverURL:    ar.options.OAuth2ServerURL,
+		tokenURL:     ar.options.OAuth2TokenURL,
+		userInfoUrl:  ar.options.OAuth2UserInfoUrl,
+		scopes:       ar.options.OAuth2Scopes,
+		cacheKey:     host,
+	}
+	if routeConfig != nil && routeConfig.OAuth2ClientId != "" {
+		eff.clientId = routeConfig.OAuth2ClientId
+		eff.clientSecret = routeConfig.OAuth2ClientSecret
+		if routeConfig.OAuth2WellKnownUrl != "" {
+			eff.wellKnownUrl = routeConfig.OAuth2WellKnownUrl
+		}
+		if routeConfig.OAuth2ServerURL != "" {
+			eff.serverURL = routeConfig.OAuth2ServerURL
+		}
+		if routeConfig.OAuth2TokenURL != "" {
+			eff.tokenURL = routeConfig.OAuth2TokenURL
+		}
+		if routeConfig.OAuth2UserInfoUrl != "" {
+			eff.userInfoUrl = routeConfig.OAuth2UserInfoUrl
+		}
+		if routeConfig.OAuth2Scopes != "" {
+			eff.scopes = routeConfig.OAuth2Scopes
+		}
+		// Use a unique cache key so per-route config does not collide with global
+		eff.cacheKey = host + "|" + eff.clientId
+	}
+	return eff
+}
+
+// HandleOAuth2Auth is the internal handler for OAuth authentication.
+// Pass a non-nil routeConfig to use per-route OAuth2 settings (e.g. a different
+// Authentik provider per virtual host). When routeConfig is nil or has no ClientId,
+// the global OAuth2 settings are used.
+func (ar *OAuth2Router) HandleOAuth2Auth(w http.ResponseWriter, r *http.Request, routeConfig *OAuth2ProviderConfig) error {
 	const callbackPrefix = "/internal/oauth2"
 	const tokenCookie = "z-token"
 	const verifierCookie = "z-verifier"
@@ -297,9 +407,26 @@ func (ar *OAuth2Router) HandleOAuth2Auth(w http.ResponseWriter, r *http.Request)
 		scheme = "https"
 	}
 
+	// Resolve effective config (per-route overrides global)
+	eff := ar.resolveEffectiveConfig(r.Host, routeConfig)
+
 	reqUrl := scheme + "://" + r.Host + r.RequestURI
-	oauthConfigCache, _ := ar.options.OAuth2ConfigCache.GetOrSetFunc(r.Host, func() *oauth2.Config {
-		oauthConfig, err := ar.newOAuth2Conf(scheme + "://" + r.Host + callbackPrefix)
+	oauthConfigCache, _ := ar.options.OAuth2ConfigCache.GetOrSetFunc(eff.cacheKey, func() *oauth2.Config {
+		var oauthConfig *oauth2.Config
+		var err error
+		if eff.cacheKey == r.Host {
+			// Global config path — keeps existing behaviour including side-effect on ar.options
+			oauthConfig, err = ar.newOAuth2Conf(scheme + "://" + r.Host + callbackPrefix)
+		} else {
+			// Per-route path — no side-effects on global options
+			var resolvedUserInfoUrl string
+			oauthConfig, resolvedUserInfoUrl, err = ar.newOAuth2ConfFromRouteConfig(
+				scheme+"://"+r.Host+callbackPrefix, eff,
+			)
+			if err == nil {
+				ar.userInfoUrlCache.Store(eff.cacheKey, resolvedUserInfoUrl)
+			}
+		}
 		if err != nil {
 			ar.options.Logger.PrintAndLog("OAuth2Router", "Failed to fetch OIDC configuration:", err)
 			return nil
@@ -313,7 +440,13 @@ func (ar *OAuth2Router) HandleOAuth2Auth(w http.ResponseWriter, r *http.Request)
 		return errors.New("failed to fetch OIDC configuration")
 	}
 
-	if oauthConfig.Endpoint.AuthURL == "" || oauthConfig.Endpoint.TokenURL == "" || ar.options.OAuth2UserInfoUrl == "" {
+	// Resolve effective userInfoUrl (per-route cache > per-route config > global)
+	effectiveUserInfoUrl := eff.userInfoUrl
+	if cached, ok := ar.userInfoUrlCache.Load(eff.cacheKey); ok {
+		effectiveUserInfoUrl = cached.(string)
+	}
+
+	if oauthConfig.Endpoint.AuthURL == "" || oauthConfig.Endpoint.TokenURL == "" || effectiveUserInfoUrl == "" {
 		ar.options.Logger.PrintAndLog("OAuth2Router", "Invalid OAuth2 configuration", nil)
 		w.WriteHeader(500)
 		return errors.New("invalid OAuth2 configuration")
@@ -387,7 +520,7 @@ func (ar *OAuth2Router) HandleOAuth2Auth(w http.ResponseWriter, r *http.Request)
 		} else {
 			ctx := context.Background()
 			client := oauthConfig.Client(ctx, &oauth2.Token{AccessToken: cookie.Value})
-			req, err := client.Get(ar.options.OAuth2UserInfoUrl)
+			req, err := client.Get(effectiveUserInfoUrl)
 			if err != nil {
 				ar.options.Logger.PrintAndLog("OAuth2", "Failed to get user info", err)
 				unauthorized = true

--- a/src/mod/dynamicproxy/authProviders.go
+++ b/src/mod/dynamicproxy/authProviders.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"imuslab.com/zoraxy/mod/auth"
+	"imuslab.com/zoraxy/mod/auth/sso/oauth2"
 	"imuslab.com/zoraxy/mod/netutils"
 )
 
@@ -42,18 +43,27 @@ func handleAuthProviderRouting(sep *ProxyEndpoint, w http.ResponseWriter, r *htt
 			return true
 		}
 	case AuthMethodForward:
+		if matchesAuthExceptionRule(r, sep) {
+			break
+		}
 		err := h.handleForwardAuth(w, r)
 		if err != nil {
 			h.Parent.Option.Logger.LogHTTPRequest(r, "host-http", 401, requestHostname, "")
 			return true
 		}
 	case AuthMethodOauth2:
-		err := h.handleOAuth2Auth(w, r)
+		if matchesAuthExceptionRule(r, sep) {
+			break
+		}
+		err := h.handleOAuth2Auth(w, r, sep.AuthenticationProvider.OAuth2Config)
 		if err != nil {
 			h.Parent.Option.Logger.LogHTTPRequest(r, "host-http", 401, requestHostname, "")
 			return true
 		}
 	case AuthMethodZorxAuth:
+		if matchesAuthExceptionRule(r, sep) {
+			break
+		}
 		err := h.handleZorxAuth(w, r)
 		if err != nil {
 			h.Parent.Option.Logger.LogHTTPRequest(r, "host-http", 401, requestHostname, "")
@@ -62,6 +72,34 @@ func handleAuthProviderRouting(sep *ProxyEndpoint, w http.ResponseWriter, r *htt
 	}
 
 	//No authentication provider, do not need to handle
+	return false
+}
+
+// matchesAuthExceptionRule checks if the request matches any configured auth exception rule.
+// Returns true if the request should bypass authentication.
+func matchesAuthExceptionRule(r *http.Request, pe *ProxyEndpoint) bool {
+	for _, exceptionRule := range pe.AuthenticationProvider.BasicAuthExceptionRules {
+		switch exceptionRule.RuleType {
+		case AuthExceptionType_Paths:
+			if strings.HasPrefix(r.RequestURI, exceptionRule.PathPrefix) {
+				return true
+			}
+		case AuthExceptionType_CIDR:
+			var requesterIp string
+			if exceptionRule.UseTrustedProxy {
+				requesterIp = netutils.GetRequesterIP(r)
+			} else {
+				requesterIp = netutils.GetRequesterIPUntrusted(r)
+			}
+			if requesterIp != "" {
+				if requesterIp == exceptionRule.CIDR ||
+					netutils.MatchIpWildcard(requesterIp, exceptionRule.CIDR) ||
+					netutils.MatchIpCIDR(requesterIp, exceptionRule.CIDR) {
+					return true
+				}
+			}
+		}
+	}
 	return false
 }
 
@@ -74,49 +112,8 @@ func (h *ProxyHandler) handleBasicAuthRouting(w http.ResponseWriter, r *http.Req
 // Handle basic auth logic
 // do not write to http.ResponseWriter if err return is not nil (already handled by this function)
 func handleBasicAuth(w http.ResponseWriter, r *http.Request, pe *ProxyEndpoint) error {
-	if len(pe.AuthenticationProvider.BasicAuthExceptionRules) > 0 {
-		//Check if the current path matches the exception rules
-		for _, exceptionRule := range pe.AuthenticationProvider.BasicAuthExceptionRules {
-			exceptionType := exceptionRule.RuleType
-			switch exceptionType {
-			case AuthExceptionType_Paths:
-				if strings.HasPrefix(r.RequestURI, exceptionRule.PathPrefix) {
-					//This path is excluded from basic auth
-					return nil
-				}
-			case AuthExceptionType_CIDR:
-				// By default, use the untrusted (RemoteAddr-only) IP to prevent header-spoofing bypass.
-				// Only trust proxy headers (X-Real-Ip, CF-Connecting-IP, etc.) when the rule
-				// was explicitly configured with UseTrustedProxy = true.
-				var requesterIp string
-				if exceptionRule.UseTrustedProxy {
-					requesterIp = netutils.GetRequesterIP(r)
-				} else {
-					requesterIp = netutils.GetRequesterIPUntrusted(r)
-				}
-				if requesterIp != "" {
-					if requesterIp == exceptionRule.CIDR {
-						// This IP is excluded from basic auth
-						return nil
-					}
-
-					wildcardMatch := netutils.MatchIpWildcard(requesterIp, exceptionRule.CIDR)
-					if wildcardMatch {
-						// This IP is excluded from basic auth
-						return nil
-					}
-
-					cidrMatch := netutils.MatchIpCIDR(requesterIp, exceptionRule.CIDR)
-					if cidrMatch {
-						// This IP is excluded from basic auth
-						return nil
-					}
-				}
-			default:
-				//Unknown exception type, skip this rule
-				continue
-			}
-		}
+	if matchesAuthExceptionRule(r, pe) {
+		return nil
 	}
 
 	u, p, ok := r.BasicAuth()
@@ -157,8 +154,8 @@ func (h *ProxyHandler) handleForwardAuth(w http.ResponseWriter, r *http.Request)
 	return h.Parent.Option.ForwardAuthRouter.HandleAuthProviderRouting(w, r)
 }
 
-func (h *ProxyHandler) handleOAuth2Auth(w http.ResponseWriter, r *http.Request) error {
-	return h.Parent.Option.OAuth2Router.HandleOAuth2Auth(w, r)
+func (h *ProxyHandler) handleOAuth2Auth(w http.ResponseWriter, r *http.Request, routeConfig *oauth2.OAuth2ProviderConfig) error {
+	return h.Parent.Option.OAuth2Router.HandleOAuth2Auth(w, r, routeConfig)
 }
 
 func (h *ProxyHandler) handleZorxAuth(w http.ResponseWriter, r *http.Request) error {

--- a/src/mod/dynamicproxy/typedef.go
+++ b/src/mod/dynamicproxy/typedef.go
@@ -197,6 +197,11 @@ type AuthenticationProvider struct {
 	ForwardAuthResponseClientHeaders  []string // List of headers to copy from the forward auth server response to the client response.
 	ForwardAuthRequestHeaders         []string // List of headers to copy from the original request to the auth server. If empty all are copied.
 	ForwardAuthRequestExcludedCookies []string // List of cookies to exclude from the request after sending it to the forward auth server.
+
+	/* OAuth2 Per-Route Settings */
+	// When OAuth2Config is non-nil and has a ClientId set, this route uses its own
+	// OAuth2 provider instead of the global one — enabling per-route Authentik providers.
+	OAuth2Config *oauth2.OAuth2ProviderConfig
 }
 
 /* CAPTCHA Provider Configuration */

--- a/src/reverseproxy.go
+++ b/src/reverseproxy.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"imuslab.com/zoraxy/mod/auth"
+	"imuslab.com/zoraxy/mod/auth/sso/oauth2"
 	"imuslab.com/zoraxy/mod/dynamicproxy"
 	"imuslab.com/zoraxy/mod/dynamicproxy/loadbalance"
 	"imuslab.com/zoraxy/mod/dynamicproxy/permissionpolicy"
@@ -784,14 +785,33 @@ func ReverseProxyHandleEditEndpoint(w http.ResponseWriter, r *http.Request) {
 	switch authProviderType {
 	case 1:
 		newProxyEndpoint.AuthenticationProvider.AuthMethod = dynamicproxy.AuthMethodBasic
+		newProxyEndpoint.AuthenticationProvider.OAuth2Config = nil
 	case 2:
 		newProxyEndpoint.AuthenticationProvider.AuthMethod = dynamicproxy.AuthMethodForward
+		newProxyEndpoint.AuthenticationProvider.OAuth2Config = nil
 	case 3:
 		newProxyEndpoint.AuthenticationProvider.AuthMethod = dynamicproxy.AuthMethodOauth2
+		// Read per-route OAuth2 provider settings
+		oauth2WellKnown, _ := utils.PostPara(r, "oauth2PerRouteWellKnown")
+		oauth2ClientId, _ := utils.PostPara(r, "oauth2PerRouteClientId")
+		oauth2ClientSecret, _ := utils.PostPara(r, "oauth2PerRouteClientSecret")
+		oauth2Scopes, _ := utils.PostPara(r, "oauth2PerRouteScopes")
+		if oauth2ClientId != "" {
+			newProxyEndpoint.AuthenticationProvider.OAuth2Config = &oauth2.OAuth2ProviderConfig{
+				OAuth2WellKnownUrl: oauth2WellKnown,
+				OAuth2ClientId:     oauth2ClientId,
+				OAuth2ClientSecret: oauth2ClientSecret,
+				OAuth2Scopes:       oauth2Scopes,
+			}
+		} else {
+			newProxyEndpoint.AuthenticationProvider.OAuth2Config = nil
+		}
 	case 4:
 		newProxyEndpoint.AuthenticationProvider.AuthMethod = dynamicproxy.AuthMethodZorxAuth
+		newProxyEndpoint.AuthenticationProvider.OAuth2Config = nil
 	default:
 		newProxyEndpoint.AuthenticationProvider.AuthMethod = dynamicproxy.AuthMethodNone
+		newProxyEndpoint.AuthenticationProvider.OAuth2Config = nil
 	}
 
 	disableAutoFallback, _ := utils.PostBool(r, "dAutoFallback")

--- a/src/web/components/httprp.html
+++ b/src/web/components/httprp.html
@@ -530,7 +530,37 @@
                                 </div>
                             </div>
                             <br>
-                            <button class="ui basic compact small button editBasicAuthCredentialsBtn" style="margin-left: 0.4em; margin-top: 0.4em;"><i class="ui blue user circle icon"></i> Basic Auth Credentials</button>
+                            <button class="ui basic compact small button editBasicAuthCredentialsBtn" style="margin-left: 0.4em; margin-top: 0.4em; display: none;"><i class="ui blue user circle icon"></i> Basic Auth Credentials</button>
+                            <!-- Per-route OAuth2 provider config (shown only when OAuth2 is selected) -->
+                            <div class="oauth2PerRouteConfig" style="display:none; margin-top: 0.8em;">
+                                <div class="ui segment" style="margin-top:0.4em;">
+                                    <h4 class="ui header" style="margin-bottom:0.6em;"><i class="yellow key icon"></i> Per-Route OAuth2 Provider</h4>
+                                    <p style="font-size:0.9em; color:#666;">Configure a dedicated OAuth2/OIDC provider for this route (e.g. a different Authentik application). Leave <b>Client ID</b> empty to use the global provider.</p>
+                                    <div class="ui form">
+                                        <div class="field">
+                                            <label>OIDC Well-Known URL <small style="color:#999">(recommended)</small></label>
+                                            <input type="text" class="oauth2PerRouteWellKnown" placeholder="https://auth.example.com/application/o/myapp/.well-known/openid-configuration" autocomplete="off">
+                                        </div>
+                                        <div class="two fields">
+                                            <div class="field">
+                                                <label>Client ID</label>
+                                                <input type="text" class="oauth2PerRouteClientId" placeholder="client-id-for-this-route" autocomplete="off">
+                                            </div>
+                                            <div class="field">
+                                                <label>Client Secret</label>
+                                                <input type="password" class="oauth2PerRouteClientSecret" placeholder="client-secret" autocomplete="off">
+                                            </div>
+                                        </div>
+                                        <div class="field">
+                                            <label>Scopes <small style="color:#999">(optional, comma-separated)</small></label>
+                                            <input type="text" class="oauth2PerRouteScopes" placeholder="openid,profile,email" autocomplete="off">
+                                        </div>
+                                        <button class="ui basic green compact small button oauth2PerRouteSaveBtn" style="margin-top:0.4em;">
+                                            <i class="save icon"></i> Save OAuth2 Config
+                                        </button>
+                                    </div>
+                                </div>
+                            </div>
                             <div class="ui divider"></div>
                             <!-- Block Common Exploits -->
                             <label><b>Exploits Prevention</b></label>
@@ -1137,6 +1167,10 @@
         let uptimeMonitorURI = $(editor).find(".UptimeMonitorURI").val().trim();
         let disableAutoFallback = false; //$(editor).find(".DisableAutoFallback")[0].checked;
         let authProviderType = $(editor).find(".authProviderPicker input[type='radio']:checked").val();
+        let oauth2PerRouteWellKnown = $(editor).find(".oauth2PerRouteWellKnown").val().trim();
+        let oauth2PerRouteClientId = $(editor).find(".oauth2PerRouteClientId").val().trim();
+        let oauth2PerRouteClientSecret = $(editor).find(".oauth2PerRouteClientSecret").val().trim();
+        let oauth2PerRouteScopes = $(editor).find(".oauth2PerRouteScopes").val().trim();
         let requireRateLimit = $(editor).find(".RequireRateLimit")[0].checked;
         let rateLimit = $(editor).find(".RateLimit").val();
         let bypassGlobalTLS = $(editor).find(".BypassGlobalTLS")[0].checked;
@@ -1178,6 +1212,10 @@
                 "dAutoFallback": disableAutoFallback,
                 "bpgtls": bypassGlobalTLS,
                 "authprovider" :authProviderType,
+                "oauth2PerRouteWellKnown": oauth2PerRouteWellKnown,
+                "oauth2PerRouteClientId": oauth2PerRouteClientId,
+                "oauth2PerRouteClientSecret": oauth2PerRouteClientSecret,
+                "oauth2PerRouteScopes": oauth2PerRouteScopes,
                 "rate" :requireRateLimit,
                 "dChunkedEnc": disableChunkedTransferEncoding,
                 "forceHTTP11": forceHTTP11,
@@ -1240,10 +1278,12 @@
 
     
     /* button events */
-    function editBasicAuthCredentials(uuid){
+    function editBasicAuthCredentials(uuid, authMethod){
+        authMethod = authMethod || 1;
         let payload = encodeURIComponent(JSON.stringify({
             ept: "host",
-            ep: uuid
+            ep: uuid,
+            authMethod: authMethod
         }));
         showEditorSideWrapper("snippet/basicAuthEditor.html?t=" + Date.now() + "#" + payload);
     }
@@ -1907,12 +1947,58 @@
             break;
         }
 
+        function updateAuthCredBtn(authMethod, editorCtx) {
+            let btn = editorCtx.find(".editBasicAuthCredentialsBtn");
+            let oauth2Panel = editorCtx.find(".oauth2PerRouteConfig");
+            if (authMethod == 0) {
+                btn.hide();
+                oauth2Panel.hide();
+            } else if (authMethod == 1) {
+                btn.show().html('<i class="ui blue user circle icon"></i> Basic Auth Credentials');
+                oauth2Panel.hide();
+            } else if (authMethod == 3) {
+                btn.show().html('<i class="ui blue shield alternate icon"></i> Auth Exceptions');
+                oauth2Panel.show();
+            } else {
+                btn.show().html('<i class="ui blue shield alternate icon"></i> Auth Exceptions');
+                oauth2Panel.hide();
+            }
+        }
+        updateAuthCredBtn(subd.AuthenticationProvider.AuthMethod, editor);
+
+        // Populate per-route OAuth2 fields from saved config
+        if (subd.AuthenticationProvider.OAuth2Config) {
+            let cfg = subd.AuthenticationProvider.OAuth2Config;
+            editor.find(".oauth2PerRouteWellKnown").val(cfg.OAuth2WellKnownUrl || "");
+            editor.find(".oauth2PerRouteClientId").val(cfg.OAuth2ClientId || "");
+            editor.find(".oauth2PerRouteClientSecret").val(cfg.OAuth2ClientSecret || "");
+            editor.find(".oauth2PerRouteScopes").val(cfg.OAuth2Scopes || "");
+        }
+
         editor.find(".authProviderPicker input[type='radio']").off("change").on("change", function() {
+            let selectedMethod = parseInt(editor.find(".authProviderPicker input[type='radio']:checked").val() || "0");
+            updateAuthCredBtn(selectedMethod, editor);
             saveProxyInlineEdit(uuid);
         });
 
+        // Save per-route OAuth2 fields on blur (when user leaves a field)
+        editor.find(".oauth2PerRouteWellKnown, .oauth2PerRouteClientId, .oauth2PerRouteClientSecret, .oauth2PerRouteScopes").off("blur").on("blur", function() {
+            saveProxyInlineEdit(uuid);
+        });
+
+        // Save button for per-route OAuth2 config
+        editor.find(".oauth2PerRouteSaveBtn").off("click").on("click", function() {
+            saveProxyInlineEdit(uuid);
+            $(this).html('<i class="check icon"></i> Saved!').addClass("green");
+            let btn = $(this);
+            setTimeout(function() {
+                btn.html('<i class="save icon"></i> Save OAuth2 Config').removeClass("green");
+            }, 2000);
+        });
+
         editor.find(".editBasicAuthCredentialsBtn").off("click").on("click", function(){
-            editBasicAuthCredentials(uuid);
+            let selectedMethod = parseInt(editor.find(".authProviderPicker input[type='radio']:checked").val() || "0");
+            editBasicAuthCredentials(uuid, selectedMethod);
         });
 
         //Rate limit

--- a/src/web/snippet/basicAuthEditor.html
+++ b/src/web/snippet/basicAuthEditor.html
@@ -14,38 +14,40 @@
         <script src="../script/darktheme.js"></script>
         <br>
         <div class="ui container">
-            <h3 class="ui header">Basic Auth Credential</h3>
-            <div class="scrolling content ui form">
-                <div id="inlineEditBasicAuthCredentials" class="field">
-                    <p>Enter the username and password for allowing them to access this proxy endpoint</p>
-                    <table class="ui basic very compacted unstackable celled table">
-                        <thead>
-                        <tr>
-                            <th>Username</th>
-                            <th>Password</th>
-                            <th>Remove</th>
-                        </tr></thead>
-                        <tbody id="inlineEditBasicAuthCredentialTable">
-                        <tr>
-                            <td colspan="3"><i class="ui green circle check icon"></i> No Entered Credential</td>
-                        </tr>
-                        </tbody>
-                    </table>
-                    <div class="three small fields credentialEntry">
-                        <div class="field">
-                            <input id="inlineEditBasicAuthCredUsername" type="text" placeholder="Username" autocomplete="off">
+            <div id="basicAuthCredentialSection">
+                <h3 class="ui header">Basic Auth Credential</h3>
+                <div class="scrolling content ui form">
+                    <div id="inlineEditBasicAuthCredentials" class="field">
+                        <p>Enter the username and password for allowing them to access this proxy endpoint</p>
+                        <table class="ui basic very compacted unstackable celled table">
+                            <thead>
+                            <tr>
+                                <th>Username</th>
+                                <th>Password</th>
+                                <th>Remove</th>
+                            </tr></thead>
+                            <tbody id="inlineEditBasicAuthCredentialTable">
+                            <tr>
+                                <td colspan="3"><i class="ui green circle check icon"></i> No Entered Credential</td>
+                            </tr>
+                            </tbody>
+                        </table>
+                        <div class="three small fields credentialEntry">
+                            <div class="field">
+                                <input id="inlineEditBasicAuthCredUsername" type="text" placeholder="Username" autocomplete="off">
+                            </div>
+                            <div class="field">
+                                <input id="inlineEditBasicAuthCredPassword" type="password" placeholder="Password" autocomplete="off">
+                            </div>
+                            <div class="field" >
+                                <button class="ui basic button" onclick="addCredentialsToEditingList();"><i class="green add icon"></i> Add Credential</button>
+                            </div>
+                            <div class="ui divider"></div>
                         </div>
-                        <div class="field">
-                            <input id="inlineEditBasicAuthCredPassword" type="password" placeholder="Password" autocomplete="off">
-                        </div>
-                        <div class="field" >
-                            <button class="ui basic button" onclick="addCredentialsToEditingList();"><i class="green add icon"></i> Add Credential</button>
-                        </div>
-                        <div class="ui divider"></div>
                     </div>
                 </div>
+                <div class="ui divider"></div>
             </div>
-            <div class="ui divider"></div>
             <h3 class="ui header">Authentication Exclusion</h3>
             <div class="scrolling content ui form">
                 <p>Exclude <b>specific directories which contains the following subpath prefix</b> or <b>IP / CIDR</b> from authentication. Useful if you are hosting services require remote API access.</p>
@@ -86,8 +88,9 @@
                     </div>
                     <div class="ui yellow message" style="margin-top: 0.6em;">
                         <i class="ui exclamation triangle icon"></i>
-                        <b>Security Warning</b><br> 
+                        <b>Security Warning</b><br>
                         Enabling this option lets Zoraxy read the client IP from HTTP headers that can be set by any client on the internet. Only enable this if Zoraxy sits <em>behind a reverse proxy you trust</em> (e.g. Cloudflare).
+                    </div>
                 </div>
                 <div class="field" >
                     <button class="ui basic button" onclick="addExceptionPath();"><i class="yellow add icon"></i> Add Exception</button>
@@ -116,9 +119,14 @@
                 let payloadHash = window.location.hash.substr(1);
                 try{
                     payloadHash = JSON.parse(decodeURIComponent(payloadHash));
-                    loadBasicAuthCredentials(payloadHash.ep);
-                    $("#epname").text(payloadHash.ep);
                     editingEndpoint = payloadHash;
+                    if (editingEndpoint.authMethod && editingEndpoint.authMethod != 1) {
+                        // Not Basic Auth: hide credentials section, show only exceptions
+                        $("#basicAuthCredentialSection").hide();
+                    } else {
+                        loadBasicAuthCredentials(payloadHash.ep);
+                    }
+                    $("#epname").text(payloadHash.ep);
                 }catch(ex){
                     console.log("Unable to load endpoint data from hash")
                 }


### PR DESCRIPTION
…ethods

- Add OAuth2ProviderConfig struct allowing each proxy route to use its own OAuth2/OIDC provider (different Authentik application, client ID and secret per virtual host)
- Apply auth exception rules (path prefix / CIDR bypass) to OAuth2, Forward Auth and ZorxAuth — previously only Basic Auth respected them
- Refactor HandleOAuth2Auth to merge per-route config over global settings with isolated cache keys (no cross-route pollution)
- Fix missing </div> in basicAuthEditor.html that hid the Add Exception button when Path Prefix mode was selected
- UI: show per-route OAuth2 config panel when OAuth2 auth method is selected; hide credentials section for non-Basic-Auth methods

Closes #1162