### PR TITLE
feat(forward-auth): add Ignored Paths 

### DIFF
--- a/src/mod/auth/sso/forward/const.go
+++ b/src/mod/auth/sso/forward/const.go
@@ -15,6 +15,7 @@ const (
 	DatabaseKeyRequestExcludedCookies = "requestExcludedCookies"
 	DatabaseKeyRequestIncludeBody     = "requestIncludeBody"
 	DatabaseKeyUseXOriginalHeaders    = "useXOriginalHeaders"
+	DatabaseKeyIgnoredPaths           = "ignoredPaths"
 
 	HeaderXForwardedProto  = "X-Forwarded-Proto"
 	HeaderXForwardedHost   = "X-Forwarded-Host"

--- a/src/mod/auth/sso/forward/forward.go
+++ b/src/mod/auth/sso/forward/forward.go
@@ -43,6 +43,12 @@ type AuthRouterOptions struct {
 	// X-Forwarded-* headers.
 	UseXOriginalHeaders bool
 
+	// IgnoredPaths is a list of request path prefixes that bypass forward auth entirely. Any
+	// request whose (normalized) path falls within one of these prefixes is served WITHOUT
+	// authentication. Used for auth callback subpaths that must not be gated, e.g. Authentik's
+	// /outpost.goauthentik.io in single-application mode. Matching is hardened against traversal.
+	IgnoredPaths []string
+
 	Logger   *logger.Logger
 	Database *database.Database
 }
@@ -60,6 +66,7 @@ func NewAuthRouter(options *AuthRouterOptions) *AuthRouter {
 	options.Database.Read(DatabaseTable, DatabaseKeyAddress, &options.Address)
 
 	responseHeaders, responseClientHeaders, requestHeaders, requestIncludedCookies, requestExcludedCookies := "", "", "", "", ""
+	ignoredPaths := ""
 
 	options.Database.Read(DatabaseTable, DatabaseKeyResponseHeaders, &responseHeaders)
 	options.Database.Read(DatabaseTable, DatabaseKeyResponseClientHeaders, &responseClientHeaders)
@@ -68,12 +75,14 @@ func NewAuthRouter(options *AuthRouterOptions) *AuthRouter {
 	options.Database.Read(DatabaseTable, DatabaseKeyRequestExcludedCookies, &requestExcludedCookies)
 	options.Database.Read(DatabaseTable, DatabaseKeyRequestIncludeBody, &options.RequestIncludeBody)
 	options.Database.Read(DatabaseTable, DatabaseKeyUseXOriginalHeaders, &options.UseXOriginalHeaders)
+	options.Database.Read(DatabaseTable, DatabaseKeyIgnoredPaths, &ignoredPaths)
 
 	options.ResponseHeaders = cleanSplit(responseHeaders)
 	options.ResponseClientHeaders = cleanSplit(responseClientHeaders)
 	options.RequestHeaders = cleanSplit(requestHeaders)
 	options.RequestIncludedCookies = cleanSplit(requestIncludedCookies)
 	options.RequestExcludedCookies = cleanSplit(requestExcludedCookies)
+	options.IgnoredPaths = cleanSplit(ignoredPaths)
 
 	r := &AuthRouter{
 		client: &http.Client{
@@ -113,6 +122,7 @@ func (ar *AuthRouter) handleOptionsGET(w http.ResponseWriter, r *http.Request) {
 		DatabaseKeyRequestExcludedCookies: ar.options.RequestExcludedCookies,
 		DatabaseKeyRequestIncludeBody:     ar.options.RequestIncludeBody,
 		DatabaseKeyUseXOriginalHeaders:    ar.options.UseXOriginalHeaders,
+		DatabaseKeyIgnoredPaths:           ar.options.IgnoredPaths,
 	})
 
 	utils.SendJSONResponse(w, string(js))
@@ -137,6 +147,7 @@ func (ar *AuthRouter) handleOptionsPOST(w http.ResponseWriter, r *http.Request) 
 	requestExcludedCookies, _ := utils.PostPara(r, DatabaseKeyRequestExcludedCookies)
 	requestIncludeBody, _ := utils.PostPara(r, DatabaseKeyRequestIncludeBody)
 	useXOriginalHeaders, _ := utils.PostPara(r, DatabaseKeyUseXOriginalHeaders)
+	ignoredPaths, _ := utils.PostPara(r, DatabaseKeyIgnoredPaths)
 
 	// Write changes to runtime
 	ar.options.Address = address
@@ -147,6 +158,7 @@ func (ar *AuthRouter) handleOptionsPOST(w http.ResponseWriter, r *http.Request) 
 	ar.options.RequestExcludedCookies = cleanSplit(requestExcludedCookies)
 	ar.options.RequestIncludeBody, _ = strconv.ParseBool(requestIncludeBody)
 	ar.options.UseXOriginalHeaders, _ = strconv.ParseBool(useXOriginalHeaders)
+	ar.options.IgnoredPaths = cleanSplit(ignoredPaths)
 
 	// Write changes to database
 	ar.options.Database.Write(DatabaseTable, DatabaseKeyAddress, address)
@@ -157,6 +169,7 @@ func (ar *AuthRouter) handleOptionsPOST(w http.ResponseWriter, r *http.Request) 
 	ar.options.Database.Write(DatabaseTable, DatabaseKeyRequestExcludedCookies, requestExcludedCookies)
 	ar.options.Database.Write(DatabaseTable, DatabaseKeyRequestIncludeBody, ar.options.RequestIncludeBody)
 	ar.options.Database.Write(DatabaseTable, DatabaseKeyUseXOriginalHeaders, ar.options.UseXOriginalHeaders)
+	ar.options.Database.Write(DatabaseTable, DatabaseKeyIgnoredPaths, ignoredPaths)
 
 	ar.logOptions()
 
@@ -172,6 +185,7 @@ func (ar *AuthRouter) handleOptionsDelete(w http.ResponseWriter, r *http.Request
 	ar.options.RequestExcludedCookies = nil
 	ar.options.RequestIncludeBody = false
 	ar.options.UseXOriginalHeaders = false
+	ar.options.IgnoredPaths = nil
 
 	ar.options.Database.Delete(DatabaseTable, DatabaseKeyAddress)
 	ar.options.Database.Delete(DatabaseTable, DatabaseKeyResponseHeaders)
@@ -181,6 +195,7 @@ func (ar *AuthRouter) handleOptionsDelete(w http.ResponseWriter, r *http.Request
 	ar.options.Database.Delete(DatabaseTable, DatabaseKeyRequestExcludedCookies)
 	ar.options.Database.Delete(DatabaseTable, DatabaseKeyRequestIncludeBody)
 	ar.options.Database.Delete(DatabaseTable, DatabaseKeyUseXOriginalHeaders)
+	ar.options.Database.Delete(DatabaseTable, DatabaseKeyIgnoredPaths)
 
 	utils.SendOK(w)
 }
@@ -272,5 +287,5 @@ func (ar *AuthRouter) handle500Error(w http.ResponseWriter, err error, message s
 }
 
 func (ar *AuthRouter) logOptions() {
-	ar.options.Logger.PrintAndLog(LogTitle, fmt.Sprintf("Forward Authz Options -> Address: %s, Response Headers: %s, Response Client Headers: %s, Request Headers: %s, Request Included Cookies: %s, Request Excluded Cookies: %s, Request Include Body: %t, Use X-Original Headers: %t", ar.options.Address, strings.Join(ar.options.ResponseHeaders, ";"), strings.Join(ar.options.ResponseClientHeaders, ";"), strings.Join(ar.options.RequestHeaders, ";"), strings.Join(ar.options.RequestIncludedCookies, ";"), strings.Join(ar.options.RequestExcludedCookies, ";"), ar.options.RequestIncludeBody, ar.options.UseXOriginalHeaders), nil)
+	ar.options.Logger.PrintAndLog(LogTitle, fmt.Sprintf("Forward Authz Options -> Address: %s, Response Headers: %s, Response Client Headers: %s, Request Headers: %s, Request Included Cookies: %s, Request Excluded Cookies: %s, Request Include Body: %t, Use X-Original Headers: %t, Ignored Paths: %s", ar.options.Address, strings.Join(ar.options.ResponseHeaders, ";"), strings.Join(ar.options.ResponseClientHeaders, ";"), strings.Join(ar.options.RequestHeaders, ";"), strings.Join(ar.options.RequestIncludedCookies, ";"), strings.Join(ar.options.RequestExcludedCookies, ";"), ar.options.RequestIncludeBody, ar.options.UseXOriginalHeaders, strings.Join(ar.options.IgnoredPaths, ";")), nil)
 }

--- a/src/mod/auth/sso/forward/ignoredpaths.go
+++ b/src/mod/auth/sso/forward/ignoredpaths.go
@@ -1,0 +1,58 @@
+package forward
+
+import (
+	"net/url"
+	"path"
+	"strings"
+)
+
+/*
+	ignoredpaths.go
+
+	Implements "Ignored Paths" for forward auth: a list of request path prefixes that bypass
+	the forward auth check entirely. Requests whose path falls within one of these prefixes are
+	served WITHOUT authentication.
+
+	The primary use case is auth-provider callback subpaths that are served on the protected
+	application's own domain and therefore must not be gated by the auth check, e.g. Authentik's
+	/outpost.goauthentik.io in single-application mode (see issue #895). It is intentionally
+	generic: any path the operator explicitly wants public can be listed.
+*/
+
+// requestPathWithinPrefix reports whether the given request URI falls *within* the supplied
+// path prefix using normalized path boundaries. It is hardened against:
+//   - boundary tricks    e.g. "/outpost.goauthentik.io.evil" must NOT match "/outpost.goauthentik.io"
+//   - path traversal     e.g. "/outpost.goauthentik.io/../admin" must NOT match (resolves to "/admin")
+//   - encoded traversal  e.g. "/outpost.goauthentik.io/%2e%2e/admin"
+//
+// This matters because a false positive would skip authentication for a path the operator
+// did not intend to expose.
+func requestPathWithinPrefix(requestURI string, prefix string) bool {
+	requestPath := requestURI
+	if u, err := url.ParseRequestURI(requestURI); err == nil {
+		//Use the decoded path only, dropping any query string / fragment
+		requestPath = u.Path
+	}
+	requestPath = path.Clean("/" + requestPath)
+	cleanedPrefix := path.Clean("/" + prefix)
+	return requestPath == cleanedPrefix || strings.HasPrefix(requestPath, cleanedPrefix+"/")
+}
+
+// IsIgnoredPath reports whether the given request URI should bypass forward auth because it
+// falls within one of the configured ignored path prefixes. Empty / whitespace-only entries
+// are skipped so a stray comma cannot accidentally disable auth for the whole site.
+func (ar *AuthRouter) IsIgnoredPath(requestURI string) bool {
+	if ar == nil {
+		return false
+	}
+	for _, prefix := range ar.options.IgnoredPaths {
+		prefix = strings.TrimSpace(prefix)
+		if prefix == "" {
+			continue
+		}
+		if requestPathWithinPrefix(requestURI, prefix) {
+			return true
+		}
+	}
+	return false
+}

--- a/src/mod/auth/sso/forward/ignoredpaths_test.go
+++ b/src/mod/auth/sso/forward/ignoredpaths_test.go
@@ -1,0 +1,74 @@
+package forward
+
+import "testing"
+
+// TestRequestPathWithinPrefix verifies the hardened path matching used by Ignored Paths. The
+// boundary and path-traversal cases are security relevant: a false positive would skip
+// authentication on a path the operator did not intend to expose.
+func TestRequestPathWithinPrefix(t *testing.T) {
+	const outpost = "/outpost.goauthentik.io"
+
+	cases := []struct {
+		name   string
+		uri    string
+		prefix string
+		want   bool
+	}{
+		{"callback with query", "/outpost.goauthentik.io/callback?code=abc&state=xyz", outpost, true},
+		{"exact", "/outpost.goauthentik.io", outpost, true},
+		{"trailing slash", "/outpost.goauthentik.io/", outpost, true},
+		{"start endpoint", "/outpost.goauthentik.io/start", outpost, true},
+		{"sign_out endpoint", "/outpost.goauthentik.io/sign_out", outpost, true},
+		{"boundary sibling", "/outpost.goauthentik.io.evil/x", outpost, false},
+		{"prefix as substring", "/outpost.goauthentik.ioxyz", outpost, false},
+		{"dot dot traversal", "/outpost.goauthentik.io/../admin", outpost, false},
+		{"encoded traversal", "/outpost.goauthentik.io/%2e%2e/admin", outpost, false},
+		{"nested traversal", "/outpost.goauthentik.io/foo/../../secret", outpost, false},
+		{"unrelated path", "/api/v1/data", outpost, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := requestPathWithinPrefix(tc.uri, tc.prefix); got != tc.want {
+				t.Errorf("requestPathWithinPrefix(%q, %q) = %v, want %v", tc.uri, tc.prefix, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestAuthRouterIsIgnoredPath verifies multi-prefix matching, that empty/whitespace entries
+// are skipped, that traversal cannot escape a configured prefix, and that an empty list never
+// bypasses authentication.
+func TestAuthRouterIsIgnoredPath(t *testing.T) {
+	ar := &AuthRouter{
+		options: &AuthRouterOptions{
+			IgnoredPaths: []string{"/outpost.goauthentik.io", "  ", "/healthz"},
+		},
+	}
+
+	cases := []struct {
+		name string
+		uri  string
+		want bool
+	}{
+		{"first prefix", "/outpost.goauthentik.io/callback?code=x", true},
+		{"second prefix exact", "/healthz", true},
+		{"second prefix subpath", "/healthz/live", true},
+		{"not listed", "/admin", false},
+		{"traversal escapes", "/outpost.goauthentik.io/../admin", false},
+		{"boundary", "/healthzzz", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ar.IsIgnoredPath(tc.uri); got != tc.want {
+				t.Errorf("IsIgnoredPath(%q) = %v, want %v", tc.uri, got, tc.want)
+			}
+		})
+	}
+
+	empty := &AuthRouter{options: &AuthRouterOptions{}}
+	if empty.IsIgnoredPath("/outpost.goauthentik.io/callback") {
+		t.Errorf("empty IgnoredPaths must never bypass authentication")
+	}
+}

--- a/src/mod/dynamicproxy/authProviders.go
+++ b/src/mod/dynamicproxy/authProviders.go
@@ -155,6 +155,12 @@ func handleBasicAuth(w http.ResponseWriter, r *http.Request, pe *ProxyEndpoint) 
 
 // Handle forward auth routing
 func (h *ProxyHandler) handleForwardAuth(w http.ResponseWriter, r *http.Request) error {
+	// Skip forward auth for SSO-ignored paths. These paths are served WITHOUT authentication
+	// (e.g. an auth provider callback subpath that must reach its own handler), so matching is
+	// hardened against path traversal / boundary tricks (see forward.IsIgnoredPath).
+	if h.Parent.Option.ForwardAuthRouter.IsIgnoredPath(r.RequestURI) {
+		return nil
+	}
 	return h.Parent.Option.ForwardAuthRouter.HandleAuthProviderRouting(w, r)
 }
 

--- a/src/web/components/sso.html
+++ b/src/web/components/sso.html
@@ -28,7 +28,7 @@
             <div class="field">
                 <label for="forwardAuthAddress">Address</label>
                 <input type="text" id="forwardAuthAddress" name="forwardAuthAddress" placeholder="Enter Forward Auth Address">
-                <small>The full remote address or URL of the authorization servers forward auth endpoint. <strong>Example:</strong> http://127.0.0.1:9091/authz/forward-auth</small>
+                <small>The full remote address or URL of the authorization servers forward auth endpoint. <strong>Example:</strong> http://127.0.0.1:9091/authz/forward-auth<br><b>Using Authentik in single-application (per-app) mode?</b> You also need to set <b>Ignored Paths</b> under Advanced Options below, and add a matching Virtual Directory on each protected host — see the note on that field.</small>
             </div>
             <div class="ui basic segment advanceoptions" style="margin-top:0.6em;">
                 <div class="ui advancedSSOForwardAuthOptions accordion">
@@ -89,9 +89,13 @@
                         <div class="field" style="margin-top: 1em;">
                             <label for="forwardAuthIgnoredPaths">Ignored Paths</label>
                             <input type="text" id="forwardAuthIgnoredPaths" name="forwardAuthIgnoredPaths" placeholder="/outpost.goauthentik.io">
-                            <div class="ui warning message" style="margin-top: 0.5em;">
-                                <div class="header"><i class="exclamation triangle icon"></i> No authentication is performed on these paths</div>
-                                <p>Comma-separated list of path prefixes that <b>bypass Forward Auth entirely</b>. Any request whose path starts with one of these prefixes is served with <b>no authentication check</b>. Use only for auth callback paths that must not be gated (e.g. Authentik per-application mode uses <code>/outpost.goauthentik.io</code>) or paths you intentionally want public. Matching is normalized — path traversal and prefix-boundary tricks are rejected.</p>
+                            <small>
+                                Comma-separated list of request path prefixes that are <b>excluded from Forward Auth</b>. Matching is normalized (path traversal and prefix-boundary tricks are rejected). <br>
+                                <strong>Authentik (single application):</strong> set this to <code>/outpost.goauthentik.io</code> and add a Virtual Directory for the same path pointing to your outpost, so the login callback can complete.
+                            </small>
+                            <div class="ui visible warning message" style="margin-top: 0.5em;">
+                                <i class="exclamation triangle icon"></i>
+                                <b>No authentication is performed on these paths.</b> Every request whose path starts with one of these prefixes bypasses Forward Auth entirely and is served with no auth check — only list paths you intentionally want public.
                             </div>
                         </div>
                     </div>

--- a/src/web/components/sso.html
+++ b/src/web/components/sso.html
@@ -86,6 +86,14 @@
                             <input type="checkbox" id="forwardAuthRequestUseXOriginalHeaders" name="forwardAuthRequestUseXOriginalHeaders" value="Use X-Original-* Headers">
                             <label for="forwardAuthRequestUseXOriginalHeaders">Use X-Original-* Headers<br><small>This is used for implementations which do not use the X-Forwarded-* headers. In addition if the authorization server responds with a 401 and Location header the status will be changed to 302.</small></label>
                         </div>
+                        <div class="field" style="margin-top: 1em;">
+                            <label for="forwardAuthIgnoredPaths">Ignored Paths</label>
+                            <input type="text" id="forwardAuthIgnoredPaths" name="forwardAuthIgnoredPaths" placeholder="/outpost.goauthentik.io">
+                            <div class="ui warning message" style="margin-top: 0.5em;">
+                                <div class="header"><i class="exclamation triangle icon"></i> No authentication is performed on these paths</div>
+                                <p>Comma-separated list of path prefixes that <b>bypass Forward Auth entirely</b>. Any request whose path starts with one of these prefixes is served with <b>no authentication check</b>. Use only for auth callback paths that must not be gated (e.g. Authentik per-application mode uses <code>/outpost.goauthentik.io</code>) or paths you intentionally want public. Matching is normalized — path traversal and prefix-boundary tricks are rejected.</p>
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -370,6 +378,11 @@
                 } else {
                     $("#forwardAuthRequestUseXOriginalHeaders").parent().checkbox("set unchecked");
                 }
+                if (data.ignoredPaths != null) {
+                    $('#forwardAuthIgnoredPaths').val(data.ignoredPaths.join(","));
+                } else {
+                    $('#forwardAuthIgnoredPaths').val("");
+                }
             },
             error: function(jqXHR, textStatus, errorThrown) {
                 console.error('Error fetching SSO settings:', textStatus, errorThrown);
@@ -391,6 +404,7 @@
         const requestExcludedCookies = $('#forwardAuthRequestExcludedCookies').val();
         const requestIncludeBody = $('#forwardAuthRequestIncludeBody').is(':checked');
         const useXOriginalHeaders = $('#forwardAuthRequestUseXOriginalHeaders').is(':checked');
+        const ignoredPaths = $('#forwardAuthIgnoredPaths').val();
 
         console.log(`Updating Forward Auth settings. Address: ${address}. Response Headers: ${responseHeaders}. Response Client Headers: ${responseClientHeaders}. Request Headers: ${requestHeaders}. Request Included Cookies: ${requestIncludedCookies}. Request Excluded Cookies: ${requestExcludedCookies}. Request Include Body: ${requestIncludeBody}. Use X-Original-* Headers: ${useXOriginalHeaders}.`);
 
@@ -406,6 +420,7 @@
                 requestExcludedCookies: requestExcludedCookies,
                 requestIncludeBody: requestIncludeBody,
                 useXOriginalHeaders: useXOriginalHeaders,
+                ignoredPaths: ignoredPaths,
             },
             success: function(data) {
                 if (data.error !== undefined) {

--- a/src/web/components/sso.html
+++ b/src/web/components/sso.html
@@ -28,7 +28,7 @@
             <div class="field">
                 <label for="forwardAuthAddress">Address</label>
                 <input type="text" id="forwardAuthAddress" name="forwardAuthAddress" placeholder="Enter Forward Auth Address">
-                <small>The full remote address or URL of the authorization servers forward auth endpoint. <strong>Example:</strong> http://127.0.0.1:9091/authz/forward-auth<br><b>Using Authentik in single-application (per-app) mode?</b> You also need to set <b>Ignored Paths</b> under Advanced Options below, and add a matching Virtual Directory on each protected host — see the note on that field.</small>
+                <small>The full remote address or URL of the authorization servers forward auth endpoint. <strong>Example:</strong> http://127.0.0.1:9091/authz/forward-auth<br><b>Using Authentik in single-application (per-app) mode?</b> You also need to set <b>Ignored Paths</b> under Advanced Options below, and add a matching Virtual Directory on each protected host, see the note on that field.</small>
             </div>
             <div class="ui basic segment advanceoptions" style="margin-top:0.6em;">
                 <div class="ui advancedSSOForwardAuthOptions accordion">


### PR DESCRIPTION
## What this does

Fixes the Authentik single-application forward-auth redirect loop (#895) by adding a generic Ignored Paths option to the (global) Forward Auth settings, a comma-separated list of request path prefixes that bypass the forward-auth check entirely.

## Setup (Authentik single-application mode)
1. Forward Auth -> Advanced Options -> Ignored Paths = `/outpost.goauthentik.io`
2. A virtual directory `/outpost.goauthentik.io` -> `<authentik-host>:9000/outpost.goauthentik.io` (Require TLS off) on each protected host, routes the OAuth callback to the outpost.

Both the Address and Ignored Paths fields carry inline notes guiding this, so it should be self-explanatory and no wiki page should be needed.

> [!WARNING]
> Paths in **Ignored Paths** get **no authentication whatsoever** — any request whose path starts with one of those prefixes bypasses Forward Auth entirely. Only list auth-callback paths (e.g. `/outpost.goauthentik.io`) or paths you intentionally want public. (This warning is also shown in the UI next to the field.)

<img width="1678" height="1054" alt="grafik" src="https://github.com/user-attachments/assets/5d762013-67dc-402a-8be0-b4edc36266b7" />

## Implementation (AI-Assisted:)

- **`forward` package:** new `IgnoredPaths` option (load / GET / POST / DELETE / log) + `IsIgnoredPath()` with
hardened, normalized matching (decoded + `path.Clean` + boundary check) so `..`/`%2e%2e` traversal and prefix-boundary
tricks can't bypass auth on unintended paths. Empty entries are skipped so a stray comma can't disable auth
site-wide.
- **`dynamicproxy/authProviders.go`:** `handleForwardAuth` returns early for ignored paths — modeled on the existing
`ZorxAuthExceptionRules` pattern. **~6 lines, no `Server.go`/routing changes**, so it stays clear of the dynamic-proxy
work on `v3.3.4`.
- **`web/components/sso.html`:** Ignored Paths field under Advanced Options, with the inline warning + Authentik hint.
- Unit tests for the matcher (boundary, traversal, multi-prefix).

## Testing
test seem to pass, builds fine and I tested this build succesfully for multiple hours and will keep it live in my homelab, though I'd appreciate any testing!

## Open question
Currently the `/outpost.goauthentik.io` vdir needs to be added manually per host. 
I'd happily add a tickbox or similar to automatically handle this, but I first wanted to hear your opinion on this and kept the PR to a basic level.

> [!NOTE]
> I'm not a professional dev and this was written largely with AI assistance. I'd be very happy if you @james-d-elliott could take a look and give it a thorough review!

Should resolve #895