### PR TITLE
feat(forward-auth): bulk apply/remove vdir for forward auth hosts

### DIFF
--- a/src/api.go
+++ b/src/api.go
@@ -64,6 +64,7 @@ func RegisterHTTPProxyAPIs(authRouter *auth.RouterDef) {
 	authRouter.HandleFunc("/api/proxy/vdir/add", ReverseProxyAddVdir)
 	authRouter.HandleFunc("/api/proxy/vdir/del", ReverseProxyDeleteVdir)
 	authRouter.HandleFunc("/api/proxy/vdir/edit", ReverseProxyEditVdir)
+	authRouter.HandleFunc("/api/proxy/vdir/bulkForwardAuth", ReverseProxyBulkApplyVdirByForwardAuth)
 	/* Reverse proxy user-defined header */
 	authRouter.HandleFunc("/api/proxy/header/list", HandleCustomHeaderList)
 	authRouter.HandleFunc("/api/proxy/header/add", HandleCustomHeaderAdd)

--- a/src/mod/dynamicproxy/endpoints.go
+++ b/src/mod/dynamicproxy/endpoints.go
@@ -97,6 +97,55 @@ func (ep *ProxyEndpoint) GetVirtualDirectoryRuleByMatchingPath(matchingPath stri
 	return nil
 }
 
+// HasSameTarget reports whether this virtual directory points at the same target as the given
+// spec (domain + TLS settings). The matching path is assumed to already be equal. Used to decide
+// whether a bulk apply/remove may treat an existing directory as "ours" (safe to skip or remove)
+// or as a user-customized one that must be left untouched.
+func (vdir *VirtualDirectoryEndpoint) HasSameTarget(domain string, requireTLS bool, skipCertValidations bool) bool {
+	return vdir.Domain == domain && vdir.RequireTLS == requireTLS && vdir.SkipCertValidations == skipCertValidations
+}
+
+// BulkVdirAction describes what a bulk virtual-directory apply/remove operation should do for one host.
+type BulkVdirAction string
+
+const (
+	BulkVdirCreate   BulkVdirAction = "create"   // directory is missing and should be created
+	BulkVdirRemove   BulkVdirAction = "remove"   // an identical directory exists and should be removed
+	BulkVdirSkip     BulkVdirAction = "skip"     // an identical directory already exists; nothing to do
+	BulkVdirConflict BulkVdirAction = "conflict" // a directory exists at this path with different settings; leave it untouched
+	BulkVdirNoop     BulkVdirAction = "noop"     // nothing present to remove
+)
+
+// ClassifyBulkVdir decides the action for a single host in a bulk virtual-directory operation,
+// given the desired target spec and the host's existing directory at the same matching path
+// (nil if none).
+//
+//	ensurePresent = true  -> make sure the directory exists (used for forward-auth hosts)
+//	ensurePresent = false -> make sure the directory is absent (used for non-forward-auth hosts)
+//
+// An existing directory is only ever skipped (when ensuring present) or removed (when ensuring
+// absent) if it has the SAME target as the spec. A directory at the same path with different
+// settings is reported as a conflict and left untouched, so user-customized directories are
+// never silently changed or deleted.
+func ClassifyBulkVdir(ensurePresent bool, existing *VirtualDirectoryEndpoint, domain string, requireTLS bool, skipCertValidations bool) BulkVdirAction {
+	if ensurePresent {
+		if existing == nil {
+			return BulkVdirCreate
+		}
+		if existing.HasSameTarget(domain, requireTLS, skipCertValidations) {
+			return BulkVdirSkip
+		}
+		return BulkVdirConflict
+	}
+	if existing == nil {
+		return BulkVdirNoop
+	}
+	if existing.HasSameTarget(domain, requireTLS, skipCertValidations) {
+		return BulkVdirRemove
+	}
+	return BulkVdirConflict
+}
+
 // Delete a vdir rule by its matching path
 func (ep *ProxyEndpoint) RemoveVirtualDirectoryRuleByMatchingPath(matchingPath string) error {
 	entryFound := false

--- a/src/mod/dynamicproxy/endpoints_test.go
+++ b/src/mod/dynamicproxy/endpoints_test.go
@@ -1,0 +1,58 @@
+package dynamicproxy
+
+import "testing"
+
+// TestVirtualDirectoryEndpointHasSameTarget verifies the target-equality check used to decide
+// whether a bulk apply/remove may treat an existing virtual directory as one it owns.
+func TestVirtualDirectoryEndpointHasSameTarget(t *testing.T) {
+	vdir := &VirtualDirectoryEndpoint{
+		MatchingPath:        "/outpost.goauthentik.io",
+		Domain:              "10.0.0.6:9000/outpost.goauthentik.io",
+		RequireTLS:          false,
+		SkipCertValidations: false,
+	}
+
+	if !vdir.HasSameTarget("10.0.0.6:9000/outpost.goauthentik.io", false, false) {
+		t.Errorf("identical target should match")
+	}
+	if vdir.HasSameTarget("10.0.0.6:9000/other", false, false) {
+		t.Errorf("different domain must not match")
+	}
+	if vdir.HasSameTarget("10.0.0.6:9000/outpost.goauthentik.io", true, false) {
+		t.Errorf("different RequireTLS must not match")
+	}
+	if vdir.HasSameTarget("10.0.0.6:9000/outpost.goauthentik.io", false, true) {
+		t.Errorf("different SkipCertValidations must not match")
+	}
+}
+
+// TestClassifyBulkVdir verifies the per-host decision for both apply (ensure present) and remove
+// (ensure absent), including that a differently-configured directory is always a conflict so it
+// is never silently overwritten or deleted.
+func TestClassifyBulkVdir(t *testing.T) {
+	const domain = "10.0.0.6:9000/outpost.goauthentik.io"
+	identical := &VirtualDirectoryEndpoint{MatchingPath: "/outpost.goauthentik.io", Domain: domain}
+	customized := &VirtualDirectoryEndpoint{MatchingPath: "/outpost.goauthentik.io", Domain: "10.0.0.6:9000/something-else"}
+
+	cases := []struct {
+		name          string
+		ensurePresent bool
+		existing      *VirtualDirectoryEndpoint
+		want          BulkVdirAction
+	}{
+		{"apply: missing -> create", true, nil, BulkVdirCreate},
+		{"apply: identical -> skip", true, identical, BulkVdirSkip},
+		{"apply: customized -> conflict", true, customized, BulkVdirConflict},
+		{"remove: absent -> noop", false, nil, BulkVdirNoop},
+		{"remove: identical -> remove", false, identical, BulkVdirRemove},
+		{"remove: customized -> conflict", false, customized, BulkVdirConflict},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ClassifyBulkVdir(tc.ensurePresent, tc.existing, domain, false, false); got != tc.want {
+				t.Errorf("ClassifyBulkVdir(ensurePresent=%v) = %q, want %q", tc.ensurePresent, got, tc.want)
+			}
+		})
+	}
+}

--- a/src/vdir.go
+++ b/src/vdir.go
@@ -290,3 +290,112 @@ func ReverseProxyEditVdir(w http.ResponseWriter, r *http.Request) {
 
 	utils.SendOK(w)
 }
+
+// ReverseProxyBulkApplyVdirByForwardAuth bulk-manages a virtual directory across hosts based on
+// their Forward Auth state, so the auth callback directory (e.g. Authentik's
+// /outpost.goauthentik.io) can be set up or torn down without per-host manual work.
+//
+//	action=add    -> create the directory on every host that USES Forward Auth
+//	action=remove -> remove the directory from every host that does NOT use Forward Auth
+//
+// Existing directories are only skipped (add) or removed when their target matches the spec
+// exactly; a directory at the same path with different settings is reported as a conflict and
+// left untouched, so nothing is silently overwritten or deleted.
+func ReverseProxyBulkApplyVdirByForwardAuth(w http.ResponseWriter, r *http.Request) {
+	action, err := utils.PostPara(r, "action")
+	if err != nil || (action != "add" && action != "remove") {
+		utils.SendErrorResponse(w, "invalid action, expected 'add' or 'remove'")
+		return
+	}
+
+	matchingPath, err := utils.PostPara(r, "path")
+	if err != nil || strings.TrimSpace(matchingPath) == "" {
+		utils.SendErrorResponse(w, "matching path not defined")
+		return
+	}
+	if !strings.HasPrefix(matchingPath, "/") {
+		matchingPath = "/" + matchingPath
+	}
+
+	domain, err := utils.PostPara(r, "domain")
+	if err != nil || strings.TrimSpace(domain) == "" {
+		utils.SendErrorResponse(w, "target domain not defined")
+		return
+	}
+
+	reqTLSStr, _ := utils.PostPara(r, "reqTLS")
+	reqTLS := (reqTLSStr == "true")
+	skipValidStr, _ := utils.PostPara(r, "skipValid")
+	skipValid := (skipValidStr == "true")
+
+	ensurePresent := (action == "add")
+
+	// Collect the target host endpoints first so we don't mutate the map while ranging it.
+	// "add" applies to hosts using Forward Auth; "remove" applies to all other hosts.
+	targets := []*dynamicproxy.ProxyEndpoint{}
+	dynamicProxyRouter.ProxyEndpoints.Range(func(key, value interface{}) bool {
+		ep, ok := value.(*dynamicproxy.ProxyEndpoint)
+		if !ok {
+			return true
+		}
+		usesForwardAuth := ep.AuthenticationProvider != nil &&
+			ep.AuthenticationProvider.AuthMethod == dynamicproxy.AuthMethodForward
+		if usesForwardAuth == ensurePresent {
+			targets = append(targets, ep)
+		}
+		return true
+	})
+
+	created := []string{}
+	removed := []string{}
+	skipped := []string{}
+	conflicts := []string{}
+	failed := []string{}
+
+	for _, ep := range targets {
+		existing := ep.GetVirtualDirectoryRuleByMatchingPath(matchingPath)
+		switch dynamicproxy.ClassifyBulkVdir(ensurePresent, existing, domain, reqTLS, skipValid) {
+		case dynamicproxy.BulkVdirCreate:
+			newVdir := dynamicproxy.VirtualDirectoryEndpoint{
+				MatchingPath:        matchingPath,
+				Domain:              domain,
+				RequireTLS:          reqTLS,
+				SkipCertValidations: skipValid,
+			}
+			activatedProxyEndpoint, addErr := ep.AddVirtualDirectoryRule(&newVdir)
+			if addErr != nil {
+				failed = append(failed, ep.RootOrMatchingDomain)
+				continue
+			}
+			SaveReverseProxyConfig(activatedProxyEndpoint)
+			created = append(created, ep.RootOrMatchingDomain)
+		case dynamicproxy.BulkVdirRemove:
+			if removeErr := ep.RemoveVirtualDirectoryRuleByMatchingPath(matchingPath); removeErr != nil {
+				failed = append(failed, ep.RootOrMatchingDomain)
+				continue
+			}
+			SaveReverseProxyConfig(ep)
+			removed = append(removed, ep.RootOrMatchingDomain)
+		case dynamicproxy.BulkVdirSkip:
+			skipped = append(skipped, ep.RootOrMatchingDomain)
+		case dynamicproxy.BulkVdirConflict:
+			conflicts = append(conflicts, ep.RootOrMatchingDomain)
+		case dynamicproxy.BulkVdirNoop:
+			// Nothing to do on this host
+		}
+	}
+
+	if len(created) > 0 || len(removed) > 0 {
+		UpdateUptimeMonitorTargets()
+	}
+
+	js, _ := json.Marshal(map[string]interface{}{
+		"action":    action,
+		"created":   created,
+		"removed":   removed,
+		"skipped":   skipped,
+		"conflicts": conflicts,
+		"failed":    failed,
+	})
+	utils.SendJSONResponse(w, string(js))
+}

--- a/src/web/components/sso.html
+++ b/src/web/components/sso.html
@@ -98,6 +98,32 @@
                                 <b>No authentication is performed on these paths.</b> Every request whose path starts with one of these prefixes bypasses Forward Auth entirely and is served with no auth check — only list paths you intentionally want public.
                             </div>
                         </div>
+                        <div class="field" style="margin-top: 1em;">
+                            <label>Callback Virtual Directory (bulk apply)</label>
+                            <small>
+                                In single-application mode the auth callback path also needs a Virtual Directory on each protected host to route it to the outpost. These buttons manage that directory across all hosts based on their Forward Auth state; a directory with different settings is never touched. <br>
+                                <strong>Add</strong> creates it on every host using Forward Auth. <strong>Remove</strong> deletes it from every host that does not (cleanup).
+                            </small>
+                            <div class="two fields" style="margin-top: 0.5em;">
+                                <div class="field">
+                                    <input type="text" id="bulkVdirPath" placeholder="/outpost.goauthentik.io">
+                                    <small>Matching path (defaults to your first Ignored Path)</small>
+                                </div>
+                                <div class="field">
+                                    <input type="text" id="bulkVdirTarget" placeholder="10.0.0.6:9000/outpost.goauthentik.io">
+                                    <small>Outpost target (host:port and path)</small>
+                                </div>
+                            </div>
+                            <div class="ui checkbox" style="margin-bottom: 0.6em;">
+                                <input type="checkbox" id="bulkVdirReqTLS">
+                                <label>Outpost requires TLS (https)</label>
+                            </div>
+                            <div>
+                                <button class="ui basic small button" type="button" id="bulkVdirAddBtn"><i class="green add icon"></i> Add to Forward Auth hosts</button>
+                                <button class="ui basic small button" type="button" id="bulkVdirRemoveBtn"><i class="red minus icon"></i> Remove from non-Forward Auth hosts</button>
+                            </div>
+                            <div id="bulkVdirResult" style="margin-top: 0.6em;"></div>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -439,6 +465,63 @@
             }
         });
     });
+
+    /* Bulk-apply / remove the auth callback virtual directory across hosts by Forward Auth state */
+    function bulkApplyForwardAuthVdir(action) {
+        var path = $('#bulkVdirPath').val().trim();
+        if (path == "") {
+            //Default to the first configured Ignored Path for convenience
+            path = ($('#forwardAuthIgnoredPaths').val() || "").split(',')[0].trim();
+        }
+        var target = $('#bulkVdirTarget').val().trim();
+        if (path == "") { msgbox("Please enter the matching path", false); return; }
+        if (target == "") { msgbox("Please enter the outpost target", false); return; }
+
+        $('#bulkVdirResult').html('<i class="notched circle loading icon"></i> Working...');
+        $.cjax({
+            url: '/api/proxy/vdir/bulkForwardAuth',
+            method: 'POST',
+            data: {
+                action: action,
+                path: path,
+                domain: target,
+                reqTLS: $('#bulkVdirReqTLS').is(':checked'),
+                skipValid: false
+            },
+            success: function(data) {
+                if (data.error !== undefined) {
+                    $('#bulkVdirResult').html('');
+                    msgbox(data.error, false);
+                    return;
+                }
+                renderBulkVdirResult(data);
+            },
+            error: function(jqXHR, textStatus, errorThrown) {
+                $('#bulkVdirResult').html('');
+                msgbox('Bulk virtual directory update failed, check console', false);
+                console.error('Bulk vdir error:', textStatus, errorThrown);
+            }
+        });
+    }
+
+    function renderBulkVdirResult(data) {
+        function line(label, arr) {
+            if (!arr || arr.length == 0) { return ''; }
+            return '<div><b>' + label + ' (' + arr.length + '):</b> ' + arr.join(', ') + '</div>';
+        }
+        var html = '';
+        html += line('Created', data.created);
+        html += line('Removed', data.removed);
+        html += line('Already up to date', data.skipped);
+        html += line('Conflicts (left untouched)', data.conflicts);
+        html += line('Failed', data.failed);
+        if (html == '') { html = 'No matching hosts.'; }
+        $('#bulkVdirResult').html('<div class="ui small message">' + html + '</div>');
+        msgbox('Bulk virtual directory ' + data.action + ' complete', true);
+    }
+
+    $('#bulkVdirAddBtn').on('click', function(){ bulkApplyForwardAuthVdir('add'); });
+    $('#bulkVdirRemoveBtn').on('click', function(){ bulkApplyForwardAuthVdir('remove'); });
 
     $( "#forwardAuthClear" ).on( "click", function( event ) {
         event.preventDefault();


### PR DESCRIPTION
Continuation of #1210

Adds an easy way to create the virtual directory that Authentik single-application Forward Auth needs, instead of adding it by hand on every host.

From Forward Auth -> Advanced Options, two buttons manage the callback vdir across all hosts by their Forward Auth state:

- Add: create it on every host that uses Forward Auth
- Remove: delete it from every host that doesn't (cleanup)

Conflict-safe, an existing directory is only skipped/removed when its target matches exactly; one at the same path with different settings is reported as a conflict and left untouched. A per-host summary (created / removed / skipped / conflicts) is shown after each run.

Adding
<img width="1551" height="608" alt="removing" src="https://github.com/user-attachments/assets/a891a5f8-b9d4-46f7-ad97-2adcb85eada5" />


Removing
<img width="1298" height="731" alt="adding" src="https://github.com/user-attachments/assets/6a112ac9-2256-4cd7-a285-28db2705d046" />


> [!NOTE]
> I'm not a professional dev and this was written largely with AI assistance, but was well vetted and tested. I'd be very happy if you can take a look and give it a thorough review!