### PR TITLE
tlscert: use name-based fallback cert instead of file renaming

### DIFF
--- a/src/mod/tlscert/handler.go
+++ b/src/mod/tlscert/handler.go
@@ -43,24 +43,24 @@ func (m *Manager) HandleCertDownload(w http.ResponseWriter, r *http.Request) {
 		utils.SendErrorResponse(w, "invalid certname given")
 		return
 	}
-	certname = filepath.Base(certname) //prevent path escape
+	certname = filepath.Base(certname) // prevent path escape
 
 	// check if the cert exists
 	pubKey := filepath.Join(filepath.Join(m.CertStore), certname+".key")
 	priKey := filepath.Join(filepath.Join(m.CertStore), certname+".pem")
 
 	if utils.FileExists(pubKey) && utils.FileExists(priKey) {
-		//Zip them and serve them via http download
+		// Zip them and serve them via http download
 		seeking, _ := utils.GetBool(r, "seek")
 		if seeking {
-			//This request only check if the key exists. Do not provide download
+			// This request only check if the key exists. Do not provide download
 			utils.SendOK(w)
 			return
 		}
 
-		//Serve both file in zip
+		// Serve both file in zip
 		zipTmpFolder := "./tmp/download"
-		os.MkdirAll(zipTmpFolder, 0775)
+		os.MkdirAll(zipTmpFolder, 0o775)
 		zipFileName := filepath.Join(zipTmpFolder, certname+".zip")
 		err := utils.ZipFiles(zipFileName, pubKey, priKey)
 		if err != nil {
@@ -74,7 +74,7 @@ func (m *Manager) HandleCertDownload(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/zip")
 		http.ServeFile(w, r, zipFileName)
 	} else {
-		//Not both key exists
+		// Not both key exists
 		utils.SendErrorResponse(w, "invalid key-pairs: private key or public key not found in key store")
 		return
 	}
@@ -88,53 +88,28 @@ func (m *Manager) SetCertAsDefault(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	//Check if the previous default cert exists. If yes, get its hostname from cert contents
-	defaultPubKey := filepath.Join(m.CertStore, "default.pem")
-	defaultPriKey := filepath.Join(m.CertStore, "default.key")
-	defaultJSON := filepath.Join(m.CertStore, "default.json")
+	certname = filepath.Base(certname) // prevent path escape
 
-	if utils.FileExists(defaultPubKey) && utils.FileExists(defaultPriKey) {
-		//Move the existing default cert to its original name
-		certBytes, err := os.ReadFile(defaultPubKey)
-		if err == nil {
-			block, _ := pem.Decode(certBytes)
-			if block != nil {
-				cert, err := x509.ParseCertificate(block.Bytes)
-				if err == nil {
-					originalKeyName := filepath.Join(m.CertStore, domainToFilename(cert.Subject.CommonName, "key"))
-					originalPemName := filepath.Join(m.CertStore, domainToFilename(cert.Subject.CommonName, "pem"))
-					originalJSONName := filepath.Join(m.CertStore, domainToFilename(cert.Subject.CommonName, "json"))
+	pubKey := filepath.Join(m.CertStore, certname+".pem")
+	priKey := filepath.Join(m.CertStore, certname+".key")
 
-					os.Rename(defaultPubKey, originalPemName)
-					os.Rename(defaultPriKey, originalKeyName)
-					if utils.FileExists(defaultJSON) {
-						os.Rename(defaultJSON, originalJSONName)
-					}
-				}
-			}
-		}
-	}
-
-	//Check if the cert exists
-	certname = filepath.Base(certname) //prevent path escape
-	pubKey := filepath.Join(filepath.Join(m.CertStore), certname+".pem")
-	priKey := filepath.Join(filepath.Join(m.CertStore), certname+".key")
-	certJSON := filepath.Join(filepath.Join(m.CertStore), certname+".json")
-	if utils.FileExists(pubKey) && utils.FileExists(priKey) {
-		os.Rename(pubKey, filepath.Join(m.CertStore, "default.pem"))
-		os.Rename(priKey, filepath.Join(m.CertStore, "default.key"))
-		if utils.FileExists(certJSON) {
-			os.Rename(certJSON, filepath.Join(m.CertStore, "default.json"))
-		}
-		utils.SendOK(w)
-
-		//Update cert list
-		m.UpdateLoadedCertList()
-
-	} else {
+	// Check if the cert exists
+	if !utils.FileExists(pubKey) || !utils.FileExists(priKey) {
 		utils.SendErrorResponse(w, "invalid key-pairs: private key or public key not found in key store")
 		return
 	}
+
+	m.FallbackCert = certname
+	m.saveFallbackConfig()
+	// Update cert list
+	m.UpdateLoadedCertList()
+	utils.SendOK(w)
+}
+
+func (m *Manager) saveFallbackConfig() {
+	fbPath := filepath.Join(m.CertStore, "fallback.json")
+	data, _ := json.Marshal(map[string]string{"fallbackCert": m.FallbackCert})
+	os.WriteFile(fbPath, data, 0o644)
 }
 
 // Handle upload of the certificate
@@ -156,7 +131,7 @@ func (m *Manager) HandleCertUpload(w http.ResponseWriter, r *http.Request) {
 	// get the domain
 	domain, err := utils.GetPara(r, "domain")
 	if err != nil {
-		//Assume localhost
+		// Assume localhost
 		domain = "default"
 	}
 
@@ -193,7 +168,7 @@ func (m *Manager) HandleCertUpload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	os.MkdirAll(m.CertStore, 0775)
+	os.MkdirAll(m.CertStore, 0o775)
 	fileMode := defaultPublicCertFileMode
 	if keytype == "pri" {
 		fileMode = defaultPrivateKeyFileMode
@@ -205,7 +180,7 @@ func (m *Manager) HandleCertUpload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	//Update cert list
+	// Update cert list
 	m.UpdateLoadedCertList()
 
 	// send response
@@ -215,7 +190,6 @@ func (m *Manager) HandleCertUpload(w http.ResponseWriter, r *http.Request) {
 // List all certificates and map all their domains to the cert filename
 func (m *Manager) HandleListDomains(w http.ResponseWriter, r *http.Request) {
 	filenames, err := os.ReadDir(m.CertStore)
-
 	if err != nil {
 		utils.SendErrorResponse(w, err.Error())
 		return
@@ -306,10 +280,10 @@ func (m *Manager) HandleListCertificate(w http.ResponseWriter, r *http.Request) 
 			certBtyes, err := os.ReadFile(certFilepath)
 			expiredIn := 0
 			if err != nil {
-				//Unable to load this file
+				// Unable to load this file
 				continue
 			} else {
-				//Cert loaded. Check its expire time
+				// Cert loaded. Check its expire time
 				block, _ := pem.Decode(certBtyes)
 				if block != nil {
 					cert, err := x509.ParseCertificate(block.Bytes)
@@ -324,8 +298,8 @@ func (m *Manager) HandleListCertificate(w http.ResponseWriter, r *http.Request) 
 				}
 			}
 			certInfoFilename := filepath.Join(m.CertStore, filename+".json")
-			useDNSValidation := false                                //Default to false for HTTP TLS certificates
-			certInfo, err := acme.LoadCertInfoJSON(certInfoFilename) //Note: Not all certs have info json
+			useDNSValidation := false                                // Default to false for HTTP TLS certificates
+			certInfo, err := acme.LoadCertInfoJSON(certInfoFilename) // Note: Not all certs have info json
 			if err == nil {
 				useDNSValidation = certInfo.UseDNS
 			}
@@ -346,7 +320,7 @@ func (m *Manager) HandleListCertificate(w http.ResponseWriter, r *http.Request) 
 				ExpireDate:       certExpireTime,
 				RemainingDays:    expiredIn,
 				UseDNS:           useDNSValidation,
-				IsFallback:       (filename == "default"), //TODO: figure out a better implementation
+				IsFallback:       (filename == m.FallbackCert), // TODO: figure out a better implementation
 			}
 
 			results = append(results, &thisCertInfo)
@@ -401,7 +375,7 @@ func (m *Manager) HandleSelfSignCertGenerate(w http.ResponseWriter, r *http.Requ
 
 	domains, err := utils.PostPara(r, "domains")
 	if err != nil {
-		//No alias domains provided, use the common name as the only domain
+		// No alias domains provided, use the common name as the only domain
 		domains = "[]"
 	}
 
@@ -421,7 +395,7 @@ func (m *Manager) HandleSelfSignCertGenerate(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	//Update the certificate store
+	// Update the certificate store
 	err = m.UpdateLoadedCertList()
 	if err != nil {
 		utils.SendErrorResponse(w, "Failed to update certificate store: "+err.Error())

--- a/src/mod/tlscert/helper.go
+++ b/src/mod/tlscert/helper.go
@@ -33,16 +33,15 @@ func getCertPairs(certFiles []string) []string {
 func domainToFilename(domain string, ext string) string {
 	// Replace wildcard '*' with '_'
 	domain = strings.TrimSpace(domain)
-	if strings.HasPrefix(domain, "*") {
-		domain = "_" + strings.TrimPrefix(domain, "*")
+	if trimDomain, ok := strings.CutPrefix(domain, "*"); ok {
+		domain = "_" + trimDomain
 	}
 
 	if strings.HasPrefix(".", ext) {
-		ext = strings.TrimPrefix(ext, ".")
+		ext = strings.TrimPrefix(ext, ".") // Ensure ext does not start with a dot
 	}
 
 	// Add .pem extension
-	ext = strings.TrimPrefix(ext, ".") // Ensure ext does not start with a dot
 	return domain + "." + ext
 }
 

--- a/src/mod/tlscert/tlscert.go
+++ b/src/mod/tlscert/tlscert.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"embed"
+	"encoding/json"
 	"encoding/pem"
 	"fmt"
 	"io"
@@ -29,9 +30,10 @@ type HostSpecificTlsBehavior struct {
 }
 
 type Manager struct {
-	CertStore   string         //Path where all the certs are stored
-	LoadedCerts []*CertCache   //A list of loaded certs
-	Logger      *logger.Logger //System wide logger for debug mesage
+	CertStore    string         //Path where all the certs are stored
+	LoadedCerts  []*CertCache   //A list of loaded certs
+	Logger       *logger.Logger //System wide logger for debug mesage
+	FallbackCert string        //Name of the fallback/default certificate (no file renaming)
 
 	/* External handlers */
 	hostSpecificTlsBehavior func(serverName string) (*HostSpecificTlsBehavior, error) // Function to get host specific TLS behavior, if nil, use global TLS options
@@ -88,6 +90,16 @@ func NewManager(certStore string, logger *logger.Logger) (*Manager, error) {
 		LoadedCerts:             []*CertCache{},
 		hostSpecificTlsBehavior: defaultHostSpecificTlsBehavior, //Default to no SNI and no auto HTTPS
 		Logger:                  logger,
+	}
+
+	// Restore fallback cert name from metadata file
+	if data, err := os.ReadFile(filepath.Join(certStore, "fallback.json")); err == nil {
+		var fb struct {
+			FallbackCert string `json:"fallbackCert"`
+		}
+		if json.Unmarshal(data, &fb) == nil && fb.FallbackCert != "" {
+			thisManager.FallbackCert = fb.FallbackCert
+		}
 	}
 
 	err := thisManager.UpdateLoadedCertList()
@@ -268,11 +280,10 @@ func (m *Manager) GetCertificateByHostname(hostname string) (string, string, err
 			//Get certificate from CA, WIP
 			//TODO: Implement AutoHTTPS
 		} else {
-			//Fallback to legacy method of matching certificates
+			//Fallback to the configured fallback certificate
 			if m.DefaultCertExists() {
-				//Use default.pem and default.key
-				pubKey = filepath.Join(m.CertStore, "default.pem")
-				priKey = filepath.Join(m.CertStore, "default.key")
+				pubKey = filepath.Join(m.CertStore, m.FallbackCert+".pem")
+				priKey = filepath.Join(m.CertStore, m.FallbackCert+".key")
 			}
 		}
 	}
@@ -281,12 +292,18 @@ func (m *Manager) GetCertificateByHostname(hostname string) (string, string, err
 
 // Check if both the default cert public key and private key exists
 func (m *Manager) DefaultCertExists() bool {
-	return utils.FileExists(filepath.Join(m.CertStore, "default.pem")) && utils.FileExists(filepath.Join(m.CertStore, "default.key"))
+	if m.FallbackCert == "" {
+		return false
+	}
+	return utils.FileExists(filepath.Join(m.CertStore, m.FallbackCert+".pem")) && utils.FileExists(filepath.Join(m.CertStore, m.FallbackCert+".key"))
 }
 
 // Check if the default cert exists returning seperate results for pubkey and prikey
 func (m *Manager) DefaultCertExistsSep() (bool, bool) {
-	return utils.FileExists(filepath.Join(m.CertStore, "default.pem")), utils.FileExists(filepath.Join(m.CertStore, "default.key"))
+	if m.FallbackCert == "" {
+		return false, false
+	}
+	return utils.FileExists(filepath.Join(m.CertStore, m.FallbackCert+".pem")), utils.FileExists(filepath.Join(m.CertStore, m.FallbackCert+".key"))
 }
 
 func sanitizeCertDomain(domain string) (string, error) {

--- a/src/mod/update/updatelogic.go
+++ b/src/mod/update/updatelogic.go
@@ -1,9 +1,12 @@
 package update
 
 import (
+	"fmt"
+
 	v308 "imuslab.com/zoraxy/mod/update/v308"
 	v315 "imuslab.com/zoraxy/mod/update/v315"
 	v322 "imuslab.com/zoraxy/mod/update/v322"
+	v334 "imuslab.com/zoraxy/mod/update/v334"
 )
 
 // Updater Core logic
@@ -25,6 +28,12 @@ func runUpdateRoutineWithVersion(fromVersion int, toVersion int) {
 		err := v322.UpdateFrom321To322()
 		if err != nil {
 			panic(err)
+		}
+	} else if fromVersion == 333 && toVersion == 334 {
+		//Updating from v3.3.3 to v3.3.4
+		//Migrate legacy default.* cert files to name-based fallback system
+		if err := v334.UpdateFrom333To334(); err != nil {
+			fmt.Println("Warning: fallback cert migration failed (non-fatal):", err)
 		}
 	}
 

--- a/src/mod/update/v334/v334.go
+++ b/src/mod/update/v334/v334.go
@@ -1,0 +1,92 @@
+// Package v334 provides migration logic from Zoraxy v3.3.3 to v3.3.4.
+//
+// It renames legacy default.pem / default.key / default.json files
+// back to their original certificate name (based on CN) and writes
+// fallback.json for the new name-based fallback system.
+package v334
+
+import (
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"imuslab.com/zoraxy/mod/utils"
+)
+
+// UpdateFrom333To334 migrates legacy default.* certificate files.
+// In older versions, setting a cert as default renamed it to default.pem/key/json.
+// This migration renames them back to their original name (based on CN in the cert)
+// and writes a fallback.json metadata file for the new name-based approach.
+func UpdateFrom333To334() error {
+	certStore := "./conf/certs"
+
+	// Check if the previous default cert exists. If yes, get its hostname from cert contents
+	defaultPubKey := filepath.Join(certStore, "default.pem")
+	defaultPriKey := filepath.Join(certStore, "default.key")
+	defaultJSON := filepath.Join(certStore, "default.json")
+
+	if !utils.FileExists(defaultPubKey) || !utils.FileExists(defaultPriKey) {
+		return nil
+	}
+
+	// Move the existing default cert to its original name
+	certBytes, err := os.ReadFile(defaultPubKey)
+	if err != nil {
+		return fmt.Errorf("failed to read %s: %w", defaultPubKey, err)
+	}
+
+	block, _ := pem.Decode(certBytes)
+	if block == nil {
+		return fmt.Errorf("failed to decode PEM in %s", defaultPubKey)
+	}
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return fmt.Errorf("failed to parse certificate in %s: %w", defaultPubKey, err)
+	}
+
+	originalName := cert.Subject.CommonName
+	originalName = strings.TrimSpace(originalName)
+	if trimDomain, ok := strings.CutPrefix(originalName, "*"); ok {
+		originalName = "_" + trimDomain
+	}
+	originalPemName := filepath.Join(certStore, originalName+".pem")
+	originalKeyName := filepath.Join(certStore, originalName+".key")
+	originalJSONName := filepath.Join(certStore, originalName+".json")
+
+	err = os.Rename(defaultPubKey, originalPemName)
+	if err != nil {
+		return fmt.Errorf("failed to rename %s to %s", defaultPubKey, originalPemName)
+	}
+	fmt.Println("Migrated " + defaultPubKey + " → " + originalPemName)
+
+	err = os.Rename(defaultPriKey, originalKeyName)
+	if err != nil {
+		return fmt.Errorf("failed to rename %s to %s", defaultPriKey, originalKeyName)
+	}
+	fmt.Println("Migrated " + defaultPriKey + " → " + originalKeyName)
+
+	if utils.FileExists(defaultJSON) {
+		err = os.Rename(defaultJSON, originalJSONName)
+		if err != nil {
+			return fmt.Errorf("failed to rename %s to %s", defaultJSON, originalJSONName)
+		}
+		fmt.Println("Migrated " + defaultJSON + " → " + originalJSONName)
+	}
+
+	fbPath := filepath.Join(certStore, "fallback.json")
+	fbData, err := json.Marshal(map[string]string{"fallbackCert": originalName})
+	if err != nil {
+		return fmt.Errorf("failed to marshal fallback config: %w", err)
+	}
+	if err := os.WriteFile(fbPath, fbData, 0o644); err != nil {
+		return fmt.Errorf("failed to write %s: %w", fbPath, err)
+	}
+	fmt.Println("Wrote " + fbPath + " with fallbackCert: " + originalName)
+
+	return nil
+}


### PR DESCRIPTION
refactor: replace file-renaming with name-based fallback cert
Instead of renaming certificate files to default.pem/key when
setting a fallback cert, store the cert name in Manager.FallbackCert
and persist it in fallback.json. This eliminates the root cause
of ACME DNS credential mismatches — since files are never moved,
database keys always stay in sync with filenames.

Changes:
- Add FallbackCert field to Manager struct
- Rewrite SetCertAsDefault to only store the name, no file renaming
- Update DefaultCertExists/Sep and TLS fallback to use FallbackCert
- Add v334 migration for legacy default.* files
- Read fallback.json on startup to restore the fallback cert name

Fix the issue raised by #1181 #1124

I've already tested it, but just to be safe, @tobychui  , could you test it ?