### PR TITLE
fix 1217: frontend js forgot to call parameter

### DIFF
--- a/src/web/components/rules.html
+++ b/src/web/components/rules.html
@@ -438,7 +438,7 @@
                                 console.log("Trying to get a new certificate via ACME");
 
                                 //Request ACME for certificate, see cert.html component
-                                obtainCertificate(rootname, defaultCA.trim(), function(){
+                                obtainCertificate(rootname, false, defaultCA.trim(), function(){
                                      // Renew the parent certificate list
                                     initManagedDomainCertificateList();
                                 });


### PR DESCRIPTION
fix #1217 
frontend js forgot to call parameter

The #rules page only allows the use of the HTTP 01 challenge. I don't have the environment to test this, but it calls the ACME function, which is consistently used, so there shouldn't be any issues.