### PR TITLE
Docker hardening

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,15 +39,6 @@ src/sys.uuid
 src/zoraxy
 src/log/
 
-# dev-tags
-/Dockerfile
-/Entrypoint.sh
-
-# docker testing stuff
-docker/test/
-docker/container-builder.sh
-docker/docker-compose.yaml
-
 # plugins
 example/plugins/ztnc/ztnc.db
 example/plugins/ztnc/authtoken.secret

--- a/docker/.gitignore
+++ b/docker/.gitignore
@@ -1,2 +1,3 @@
 src/
+test/
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,5 @@
 ## Build Zoraxy
 FROM docker.io/golang:alpine AS build-zoraxy
-
 RUN mkdir -p /opt/zoraxy/source/ &&\
     mkdir -p /usr/local/bin/
 
@@ -16,13 +15,12 @@ RUN go mod tidy &&\
 
 ## Build ZeroTier
 FROM docker.io/rust:1.79-alpine AS build-zerotier
+RUN apk add --update --no-cache curl make gcc g++ linux-headers openssl-dev nano
 
 RUN mkdir -p /opt/zerotier/source/ &&\
     mkdir -p /usr/local/bin/
 
 WORKDIR /opt/zerotier/source/
-
-RUN apk add --update --no-cache curl make gcc g++ linux-headers openssl-dev nano
 
 # Version is pinned because newer versions don't work for whatever reason
 RUN curl -Lo ZeroTierOne.tar.gz https://codeload.github.com/zerotier/ZeroTierOne/tar.gz/refs/tags/1.10.6 &&\
@@ -37,9 +35,8 @@ RUN curl -Lo ZeroTierOne.tar.gz https://codeload.github.com/zerotier/ZeroTierOne
 
 ## Main
 FROM docker.io/alpine:latest
-
 RUN apk add --update --no-cache tzdata python3 sudo netcat-openbsd libressl-dev openssh ca-certificates libc6-compat libstdc++ &&\
-    rm -rf /var/cache/apk/* /tmp/* # Simple cleanup
+    rm -rf /sbin/apk /var/cache/apk/* /tmp/* # Simple cleanup
 
 COPY --chmod=700 ./entrypoint.py /opt/zoraxy/
 
@@ -77,5 +74,5 @@ LABEL com.imuslab.zoraxy.container-identifier="Zoraxy"
 
 ENTRYPOINT [ "python3", "-u", "/opt/zoraxy/entrypoint.py" ]
 
-HEALTHCHECK --interval=15s --timeout=5s --start-period=10s --retries=3 CMD nc -vz 127.0.0.1 $PORT || exit 1
+HEALTHCHECK --start-period=5s --interval=15s --timeout=5s --retries=3 CMD nc -vz 127.0.0.1 $PORT || exit 1
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -108,6 +108,7 @@ Variables are the same as those in [Start Parameters](https://github.com/tobychu
 If you are running with ZeroTier, make sure to add the following flags to ensure ZeroTier functionality:
   
 `--cap_add NET_ADMIN` and `--device /dev/net/tun:/dev/net/tun`
+`--environment ZEROTIER="true"`
 
 Or for Docker Compose:
 ```
@@ -115,6 +116,8 @@ Or for Docker Compose:
     - NET_ADMIN
   devices:
     - /dev/net/tun:/dev/net/tun
+  environment:
+    ZEROTIER: "true"
 ```
 
 ### Plugins

--- a/docker/docker-compose-test.yaml
+++ b/docker/docker-compose-test.yaml
@@ -1,0 +1,29 @@
+services:
+  test-zoraxy:
+    image: test-zoraxy
+    container_name: test-zoraxy
+    restart: 'no'
+    cap_add:
+      - NET_ADMIN
+    devices:
+      - /dev/net/tun:/dev/net/tun
+    volumes:
+      - ./test/config/:/opt/zoraxy/config/:rw
+      - ./test/plugin/:/opt/zoraxy/plugin/:rw
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    environment:
+      TZ: "America/New_York"
+      DB: "auto"
+      PORT: "8005"
+      FASTGEOIP: "true"
+      EARLYRENEW: "14"
+      AUTORENEW: "2000"
+      ZEROTIER: "true"
+    ports:
+      - 80:80/tcp
+      - 443:443/tcp
+      - 8005:8005/tcp
+      - 6754:6754
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+

--- a/docker/flake.lock
+++ b/docker/flake.lock
@@ -1,0 +1,48 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1769996383,
+        "narHash": "sha256-AnYjnFWgS49RlqX7LrC4uA+sCCDBj0Ry/WOJ5XWAsa0=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "57928607ea566b5db3ad13af0e57e921e6b12381",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1772173633,
+        "narHash": "sha256-MOH58F4AIbCkh6qlQcwMycyk5SWvsqnS/TCfnqDlpj4=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "c0f3d81a7ddbc2b1332be0d8481a672b4f6004d6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/docker/flake.nix
+++ b/docker/flake.nix
@@ -1,0 +1,65 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+
+    flake-parts = {
+      url = "github:hercules-ci/flake-parts";
+      inputs.nixpkgs-lib.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { ... } @ inputs:
+  inputs.flake-parts.lib.mkFlake { inherit inputs; } {
+    systems = [ "x86_64-linux" ];
+
+    perSystem = { self', system, ... }:
+    let
+      pkgs = import inputs.nixpkgs { inherit system; };
+      lib = pkgs.lib;
+    in
+    {
+      devShells = {
+        default = pkgs.mkShell {
+          packages = with pkgs; [
+            act dive trivy
+          ];
+          shellHook = ''
+            alias nr="nix run .#"
+          '';
+        };
+      };
+      packages = let
+        build = lib.getExe self'.packages.build;
+      in {
+        default = self'.packages.test;
+        build = pkgs.writeShellApplication {
+          name = "build";
+          runtimeInputs = with pkgs; [ docker ];
+          text = ''
+            cp -lr ../src/ ./
+            docker build . -t test-zoraxy --cache-from zoraxydocker/zoraxy:latest ;\
+            rm -r ./src/
+          '';
+          meta.mainProgram = "build";
+        };
+        test = pkgs.writeShellApplication {
+          name = "test-container";
+          runtimeInputs = with pkgs; [ docker ];
+          text = ''
+            ${build}
+            docker compose -f ./docker-compose-test.yaml up
+          '';
+        };
+        trivy = pkgs.writeShellApplication {
+          name = "trivy-image";
+          runtimeInputs = with pkgs; [ docker trivy ];
+          text = ''
+            ${build}
+            trivy image test-zoraxy
+          '';
+        };
+      };
+    };
+  };
+}
+

--- a/src/go.mod
+++ b/src/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/armon/go-radix v1.0.0
 	github.com/c0va23/go-proxyprotocol v0.9.1
-	github.com/docker/docker v27.1.1+incompatible
+	github.com/moby/moby/client v0.3.0
 	github.com/go-acme/lego/v4 v4.35.2
 	github.com/go-ping/ping v1.1.0
 	github.com/go-webauthn/webauthn v0.17.4
@@ -21,7 +21,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/syndtr/goleveldb v1.0.0
 	go.etcd.io/bbolt v1.4.1
-	golang.org/x/net v0.54.0
+	golang.org/x/net v0.55.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/text v0.37.0
 )

--- a/src/mod/dockerux/docker.go
+++ b/src/mod/dockerux/docker.go
@@ -8,9 +8,7 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/client"
+	"github.com/moby/moby/client"
 	"imuslab.com/zoraxy/mod/utils"
 )
 
@@ -28,14 +26,14 @@ func (d *UXOptimizer) HandleDockerContainersList(w http.ResponseWriter, r *http.
 	}
 	defer apiClient.Close()
 
-	containers, err := apiClient.ContainerList(context.Background(), container.ListOptions{All: true})
+	containers, err := apiClient.ContainerList(context.Background(), client.ContainerListOptions{All: true})
 	if err != nil {
 		d.SystemWideLogger.PrintAndLog("Docker", "List docker container failed", err)
 		utils.SendErrorResponse(w, "List docker container failed")
 		return
 	}
 
-	networks, err := apiClient.NetworkList(context.Background(), types.NetworkListOptions{})
+	networks, err := apiClient.NetworkList(context.Background(), client.NetworkListOptions{})
 	if err != nil {
 		d.SystemWideLogger.PrintAndLog("Docker", "List docker network failed", err)
 		utils.SendErrorResponse(w, "List docker network failed")
@@ -43,8 +41,8 @@ func (d *UXOptimizer) HandleDockerContainersList(w http.ResponseWriter, r *http.
 	}
 
 	result := map[string]interface{}{
-		"network":    networks,
-		"containers": containers,
+		"network":    networks.Items,
+		"containers": containers.Items,
 	}
 
 	js, err := json.Marshal(result)


### PR DESCRIPTION
Remove Alpine apk binary from image

Fix some CVEs:
x/net v0.54.0 -> v0.55.0

Updated Docker to v29:
docker/docker -> moby/moby/client v0.3.0
Removed docker/docker/api
Fixed docker.go response handling

Updating gorilla/csrf to v1.7.3 would fix another CVE, but that breaks account creation for some reason.

Additionally but irrelevant, Zerotier does not work on v3.3.4-rc1. I'm able to see my Network Controller ID, but using create network errors: `Network error. status code: 404`