### PR TITLE
Feature (acme): custom acme preferred ca

### DIFF
--- a/src/acme.go
+++ b/src/acme.go
@@ -6,9 +6,11 @@ import (
 	"io"
 	"math/rand"
 	"net/http"
+	"net/url"
 	"os"
 	"regexp"
 	"strconv"
+	"strings"
 	"time"
 
 	"imuslab.com/zoraxy/mod/acme"
@@ -177,16 +179,52 @@ func AcmeCheckAndHandleRenewCertificate(w http.ResponseWriter, r *http.Request) 
 
 // HandleACMEPreferredCA return the user preferred / default CA for new subdomain auto creation
 func HandleACMEPreferredCA(w http.ResponseWriter, r *http.Request) {
+
+	type PreferredCA struct {
+		Name string `json:"name"`
+		URL  string `json:"url"`
+		SkipTLS bool `json:"skipTLS"`
+	}
+
 	ca, err := utils.PostPara(r, "set")
 	if err != nil {
 		//Return the current ca to user
 		prefCA := "Let's Encrypt"
+		prefCAURL := ""
+		skipTLS := false
 		sysdb.Read("acmepref", "prefca", &prefCA)
-		js, _ := json.Marshal(prefCA)
+		sysdb.Read("acmepref", "prefcaurl", &prefCAURL)
+		sysdb.Read("acmepref", "skipTLS", &skipTLS)
+		js, _ := json.Marshal(PreferredCA{
+			Name: prefCA,
+			URL:  prefCAURL,
+			SkipTLS: skipTLS,
+		})
 		utils.SendJSONResponse(w, string(js))
 	} else {
 		//Check if the CA is supported
-		acme.IsSupportedCA(ca, *acmeTestMode)
+		isSupported := acme.IsSupportedCA(ca, *acmeTestMode)
+		
+		if !isSupported && ca != "custom" {
+			utils.SendErrorResponse(w, "The specified ACME CA is not supported")
+			return
+		}
+
+		if ca == "custom" {
+			customCAURL, err := utils.PostPara(r, "customURL")
+			customCAURL = strings.TrimSpace(customCAURL)
+			parsedURL, err2 := url.Parse(customCAURL)
+			skipTLS, _ := utils.PostBool(r, "SkipTLS")
+
+			if err != nil || err2 != nil || (parsedURL.Scheme != "http" && parsedURL.Scheme != "https") || parsedURL.Host == "" {
+				utils.SendErrorResponse(w, "Invalid custom CA URL provided")
+				return
+			}
+			sysdb.Write("acmepref", "prefcaurl", customCAURL)
+			SystemWideLogger.Println("Updating prefered ACME CA URL to " + customCAURL)
+			sysdb.Write("acmepref", "skipTLS", skipTLS)
+			SystemWideLogger.Println("Updating prefered skipTLS to " + fmt.Sprintf("%t", skipTLS))
+		} 
 		//Set the new config
 		sysdb.Write("acmepref", "prefca", ca)
 		SystemWideLogger.Println("Updating prefered ACME CA to " + ca)

--- a/src/web/components/acme.html
+++ b/src/web/components/acme.html
@@ -48,12 +48,31 @@
                     <div class="item" data-value="Let's Encrypt">Let's Encrypt</div>
                     <!-- <div class="item" data-value="Buypass">Buypass</div> -->
                     <div class="item" data-value="ZeroSSL">ZeroSSL</div>
+                    <div class="item" data-value="custom">Custom ACME Server</div>
                 </div>
             </div>
         </div>
         <div class="field">
             <label>ACME Email</label>
             <input id="prefACMEEmail" type="text" placeholder="ACME Email">
+        </div>
+        <div class="field" id="prefcaInput" style="display:none;">
+            <label>ACME Server URL</label>
+            <input id="prefcaURL" type="text" placeholder="https://example.com/acme/directory">
+        </div>
+        <div class="field" id="prefkidInput" style="display:none;">
+            <label>EAB Credentials (KID) for current provider</label>
+            <input id="prefeab_kid" type="text" placeholder="Leave this field blank to keep the current configuration">
+        </div>
+        <div class="field" id="prefhmacInput" style="display:none;">
+            <label>EAB HMAC Key for current provider</label>
+            <input id="prefeab_hmac" type="text" placeholder="Leave this field blank to keep the current configuration">
+        </div>
+        <div class="field" id="skipTLS" style="display:none;">
+            <div class="ui checkbox">
+                <input type="checkbox" id="skipTLSCheckbox">
+                <label>Ignore TLS/SSL Verification Error<br><small>E.g. self-signed, expired certificate (Not Recommended)</small></label>
+            </div>
         </div>
         <button class="ui basic button" onclick="saveDefaultCA();"><i class="ui green save icon"></i> Save</button>
     </div>
@@ -320,13 +339,35 @@
         });
 
         $.get("/api/acme/autoRenew/ca", function(data){
-            $("#defaultCA").dropdown("set value", data);
+            $("#defaultCA").dropdown("set value", data.name);
+            $("#prefcaURL").val(data.url || "");
+            updatePrefCaFields(data.name);
         });
 
         initToggleState();
         initDomainFileList();
+
     }
     initAcmeStatus();
+
+    function updatePrefCaFields(value){
+        if (value === "custom"){
+            $("#prefcaInput").show();
+            $("#prefkidInput").show();
+            $("#prefhmacInput").show();
+            $("#skipTLS").show();
+        } else if (value === "ZeroSSL"){
+            $("#prefcaInput").hide();
+            $("#prefkidInput").show();
+            $("#prefhmacInput").show();
+            $("#skipTLS").hide();
+        } else {
+            $("#prefcaInput").hide();
+            $("#prefkidInput").hide();
+            $("#prefhmacInput").hide();
+            $("#skipTLS").hide();
+        }
+    }
 
     // Global exports
     // setACMEEnableStates is also called from snippet/acme.html via parent.setACMEEnableStates
@@ -340,12 +381,30 @@
         $("#acmeAutoRenewer").find("i").attr("class", enabled ? "white circle check icon" : "white circle times icon");
     };
 
+    $("input[name=defaultCA]").on("change", function(){
+        updatePrefCaFields($(this).val());
+    });
+
     window.saveDefaultCA = function(){
         var newDefaultEmail = $("#prefACMEEmail").val().trim();
         var newDefaultCA = $("#defaultCA").dropdown("get value");
+        var newCustomCAURL = $("#prefcaURL").val().trim();
+        var newEABKID = $("#prefeab_kid").val().trim();
+        var newEABHMAC = $("#prefeab_hmac").val().trim();
+        var skipTLSValue = $("#skipTLSCheckbox")[0].checked;
+        var eabDirectoryURL = ""
+
 
         if (newDefaultEmail == ""){
             msgbox("Invalid acme email given", false);
+            return;
+        }
+        if ((newDefaultCA === "ZeroSSL" || newDefaultCA === "custom") && (newEABKID == "" && newEABHMAC != "") || (newEABKID != "" && newEABHMAC == "")){
+            msgbox("EAB KID and HMAC key must be both provided or empty for ZeroSSL", false);
+            return;
+        } 
+        if (newDefaultCA == "custom" && newCustomCAURL == ""){
+            msgbox("Invalid custom acme server url given", false);
             return;
         }
 
@@ -365,7 +424,11 @@
 
         $.cjax({
             url: "/api/acme/autoRenew/ca",
-            data: {"set": newDefaultCA},
+            data: {
+                set: newDefaultCA, 
+                customURL: newCustomCAURL, 
+                skipTLS: skipTLSValue
+            },
             method: "POST",
             success: function(data){
                 if (data.error != undefined){
@@ -373,6 +436,30 @@
                 }
             }
         });
+
+
+        if (newDefaultCA == "ZeroSSL"){
+            eabDirectoryURL = "https://acme.zerossl.com/v2/DV90";
+        } else if (newDefaultCA == "custom"){
+            eabDirectoryURL = newCustomCAURL;
+        }
+
+        if (eabDirectoryURL != "" && newEABKID != "" && newEABHMAC != ""){
+            $.ajax({
+                url: "/api/acme/autoRenew/setEAB",
+                method: "GET",
+                data: {
+                acmeDirectoryURL: eabDirectoryURL,
+                kid: newEABKID,
+                hmacEncoded: newEABHMAC,
+                },
+                success: function(data) {
+                    if (data.error != undefined) {
+                        msgbox("EAB update failed: " + data.error, false);
+                    }
+                }
+            });
+        }
 
         msgbox("Settings updated");
     };

--- a/src/web/components/cert.html
+++ b/src/web/components/cert.html
@@ -255,38 +255,59 @@
             //Filename cannot contain wildcards, and wildcards are possible with DNS challenges
             filename = filename.replace("*", "_");
 
-            $.ajax({
-                url: "/api/acme/obtainCert",
-                method: "GET",
-                data: {
-                    domains: domains,
-                    filename: filename,
-                    email: email,
-                    ca: usingCa,
-                    dns: dns
-                },
-                success: function(response) {
-                    if (response.error) {
-                        console.log("Error:", response.error);
-                        // Show error message
-                        msgbox(response.error, false, 12000);
+            let requestCert = function(caURL="", skipTLSValue=false){
+                $.ajax({
+                    url: "/api/acme/obtainCert",
+                    method: "GET",
+                    data: {
+                        domains: domains,
+                        filename: filename,
+                        email: email,
+                        ca: usingCa,
+                        caURL: caURL,
+                        skipTLS: skipTLSValue,
+                        dns: dns,
+                    },
+                    success: function(response) {
+                        if (response.error) {
+                            console.log("Error:", response.error);
+                            // Show error message
+                            msgbox(response.error, false, 12000);
+                            if (callback != undefined){
+                                callback(false);
+                            }
+                        } else {
+                            console.log("Certificate installed successfully");
+                            // Show success message
+                            msgbox("Certificate installed successfully");
+                            
+                            if (callback != undefined){
+                                callback(true);
+                            }
+                        }
+                    },
+                    error: function(error) {
+                        console.log("Failed to install certificate:", error);
+                    }
+                });
+            }
+
+            if (usingCa == "custom"){
+                $.get("/api/acme/autoRenew/ca", function(data){
+                    if (data.url == undefined || data.url.trim() == ""){
+                        msgbox("Custom ACME URL not set.", false);
                         if (callback != undefined){
                             callback(false);
                         }
-                    } else {
-                        console.log("Certificate installed successfully");
-                        // Show success message
-                        msgbox("Certificate installed successfully");
-                        
-                        if (callback != undefined){
-                            callback(true);
-                        }
+                        return;
                     }
-                },
-                error: function(error) {
-                    console.log("Failed to install certificate:", error);
-                }
-            });
+                    requestCert(data.url.trim(), data.skipTLS);
+                })
+            } else {
+                requestCert();
+            }
+
+            
         });
     }
 


### PR DESCRIPTION
The Preferred CA setting only supported the CAs hardcoded in ca.json. The Generate New Certificate tool already supports custom ACME directory URLs, but there was no way to make a custom server the default CA.

This PR adds the ability to add a custom CA URL, as well as set EAB credentials for both custom and for ZeroSSL certs.

Closes #1199, closes #1084, closes #383

## Changes
The GET response of `/api/acme/autoRenew/ca` changed from a bare string `"Let's Encrypt"` to an object. The only consumer, `acme.html`, is updated in this PR. 

`IsSupportedCA` was previously being called but not used, saving an unsupported CA name is now rejected at save

Switching from custom back to a named CA keeps the stored URL, so switching back restores the URL, consumers only read the URL when CA is `custom`

## Screenshots
<img width="1604" height="559" alt="image" src="https://github.com/user-attachments/assets/fd4b196a-cffe-4e76-af62-4c9bb051fa6a" />
<img width="1604" height="432" alt="image" src="https://github.com/user-attachments/assets/afe82fd3-187e-4782-9f30-1f98dd950f5a" />


