### PR TITLE
Fix HTTP proxy rate limit UI not loading per-host value (#1107)

### DIFF
--- a/src/web/components/httprp.html
+++ b/src/web/components/httprp.html
@@ -581,7 +581,7 @@
                             <div class="ui divider"></div>
                             <!-- Rate Limits-->
                             <div class="ui checkbox" style="margin-top: 0.4em;">
-                                <input type="checkbox" onchange="handleToggleRateLimitInput();" class="RequireRateLimit" ${rateLimitCheckState}>
+                                <input type="checkbox" class="RequireRateLimit">
                                 <label>Require Rate Limit<br>
                                 <small>Check this to enable rate limit on this inbound hostname</small></label>
                             </div><br>
@@ -1024,17 +1024,6 @@
         //Show the HTTP Proxy Rule Editor Modal
         initHttpProxyRuleEditorModal(payload);
         return;
-    }
-
-    //handleToggleRateLimitInput will get trigger if the "require rate limit" checkbox
-    // is changed and toggle the disable state of the rate limit input field
-    function handleToggleRateLimitInput(){
-        let isRateLimitEnabled = $("#httpProxyList input.RequireRateLimit")[0].checked;
-        if (isRateLimitEnabled){
-            $("#httpProxyList input.RateLimit").parent().removeClass("disabled");
-        }else{
-            $("#httpProxyList input.RateLimit").parent().addClass("disabled");
-        }
     }
 
     function exitProxyInlineEdit(){
@@ -1955,7 +1944,7 @@
             editZorxAuthExceptions(uuid);
         });
 
-        //Rate limit
+        // Rate limit: load with .val() so the shared modal shows each proxy's saved value (#1107)
         if (subd.RequireRateLimit) {
             editor.find(".RequireRateLimit").prop("checked", true);
             editor.find(".RateLimit").parent().removeClass("disabled");
@@ -1971,6 +1960,7 @@
                 $(this).val(subd.RateLimit); // Reset to previous valid value
                 return;
             }
+            subd.RateLimit = parseInt(rateLimitValue, 10) || 0;
             saveProxyInlineEdit(uuid);
         }
 
@@ -1983,14 +1973,13 @@
 
             if (subd.RateLimit === 0) {
                 subd.RateLimit = 100; // Set default rate limit to 100 if uninitialized
-                $(this).val(subd.RateLimit);
                 editor.find(".RateLimit").off("change"); // Temporarily disable the change event handler
                 editor.find(".RateLimit").val(100); // Set the value to 100
                 editor.find(".RateLimit").on("change", rateLimitChangeEvent); // Re-enable the change event handler
             }
             saveProxyInlineEdit(uuid);
         });
-        editor.find(".RateLimit").attr("value", subd.RateLimit);
+        editor.find(".RateLimit").val(subd.RateLimit);
         editor.find(".RateLimit").off("change").on("change", rateLimitChangeEvent);
 
         // CAPTCHA Gating

--- a/src/web/components/httprp.html
+++ b/src/web/components/httprp.html
@@ -1945,6 +1945,8 @@
         });
 
         // Rate limit: load with .val() so the shared modal shows each proxy's saved value (#1107)
+        editor.find(".RateLimit").off("change.ratelimit");
+        editor.find(".RequireRateLimit").off("change.ratelimit");
         if (subd.RequireRateLimit) {
             editor.find(".RequireRateLimit").prop("checked", true);
             editor.find(".RateLimit").parent().removeClass("disabled");
@@ -1954,17 +1956,22 @@
         }
 
         function rateLimitChangeEvent(){
-            let rateLimitValue = $(this).val();
-            if (rateLimitValue < 0 || isNaN(rateLimitValue)) {
-                msgbox("Rate limit must be >= 0", false);
-                $(this).val(subd.RateLimit); // Reset to previous valid value
+            let rateLimitValue = String($(this).val()).trim();
+            if (rateLimitValue === "") {
+                $(this).val(subd.RateLimit);
                 return;
             }
-            subd.RateLimit = parseInt(rateLimitValue, 10) || 0;
+            let parsed = parseInt(rateLimitValue, 10);
+            if (isNaN(parsed) || parsed < 0) {
+                msgbox("Rate limit must be >= 0", false);
+                $(this).val(subd.RateLimit);
+                return;
+            }
+            subd.RateLimit = parsed;
             saveProxyInlineEdit(uuid);
         }
 
-        editor.find(".RequireRateLimit").off("change").on("change", function() {
+        editor.find(".RequireRateLimit").on("change.ratelimit", function() {
             if ($(this).is(":checked")) {
                 editor.find(".RateLimit").parent().removeClass("disabled");
             } else {
@@ -1973,14 +1980,11 @@
 
             if (subd.RateLimit === 0) {
                 subd.RateLimit = 100; // Set default rate limit to 100 if uninitialized
-                editor.find(".RateLimit").off("change"); // Temporarily disable the change event handler
-                editor.find(".RateLimit").val(100); // Set the value to 100
-                editor.find(".RateLimit").on("change", rateLimitChangeEvent); // Re-enable the change event handler
+                editor.find(".RateLimit").val(100);
             }
             saveProxyInlineEdit(uuid);
         });
-        editor.find(".RateLimit").val(subd.RateLimit);
-        editor.find(".RateLimit").off("change").on("change", rateLimitChangeEvent);
+        editor.find(".RateLimit").val(subd.RateLimit).on("change.ratelimit", rateLimitChangeEvent);
 
         // CAPTCHA Gating
         if (subd.RequireCaptcha) {


### PR DESCRIPTION
## Summary

Fixes #1107.

The HTTP Proxy Security editor reuses one modal for every host. When loading a host's rate limit, the UI called jQuery `.attr('value', ...)`, which updates the HTML attribute but not a dirty input's live value. After editing host A to 200 and host B to 300, reopening A still showed 300 even though the backend config for A stayed at 200 (as tobychui noted on the issue).

### Changes
- Load `.RateLimit` with `.val(subd.RateLimit)` so switching hosts refreshes the visible number.
- Keep the in-memory `subd.RateLimit` in sync on change (validation reset).
- Remove the unused `handleToggleRateLimitInput` / inline `onchange` path (it selected inputs under `#httpProxyList`, but the rate limit controls live in the modal). The modal already has a scoped change handler.

## AI assistance

This patch was drafted with AI assistance (Cursor / Grok). I reviewed the root cause against the issue report and the maintainer note that config save was already correct.

## Evidence

Dirty-value model of the shared `<input type='number'>` (WHATWG: after `.value` is set, `setAttribute('value', ...)` does not change the live value):

```
BUGGY .attr only: shown=300 attr=200
FIXED .val: shown=200
PASS: reproduces #1107 and fix restores per-proxy value
```

Code path checked at HEAD `0e0a385`: bug still present before this commit; `v3.3.4` still uses `.attr('value', subd.RateLimit)`. No covering open PR found for #1107.

Backend `RequireRateLimit` / `RateLimit` on `ProxyEndpoint` was already per-proxy; only the editor load path was wrong.

### What was not tested
- Full Zoraxy admin UI live click-through in a running Docker instance on this machine (static web asset change; logic is the DOM value load).
- Access-rule / create-proxy form in `rules.html` (separate create form with its own ids; not the shared edit modal).

Made with [Cursor](https://cursor.com)