### PR TITLE
Fix SSO redirect loop when SSO URL omits http(s) scheme

### DIFF
--- a/src/mod/auth/sso/zorxauth/routers.go
+++ b/src/mod/auth/sso/zorxauth/routers.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
-	"net/url"
 	"strings"
 	"time"
 )
@@ -218,6 +217,26 @@ func (ar *AuthRouter) setAuthHeaders(r *http.Request, user *User) {
 	}
 }
 
+// buildLoginRedirectURL returns the absolute SSO login URL for an unauthenticated request.
+// Host-only SSORedirectURL values are normalized so they are never treated as relative paths.
+func (ar *AuthRouter) buildLoginRedirectURL(r *http.Request) (string, error) {
+	if ar.Options.SSORedirectURL == "" {
+		return "", errors.New("SSO Redirect URL is not set")
+	}
+
+	scheme := requestScheme(r)
+	ssoBase, err := ensureAbsoluteHTTPURL(ar.Options.SSORedirectURL, scheme)
+	if err != nil {
+		return "", errors.New("SSO Redirect URL is invalid: " + err.Error())
+	}
+	if ssoRedirectWouldLoop(ssoBase, r) {
+		return "", errors.New("SSO Redirect URL resolves to the same host as the protected request")
+	}
+
+	originalURL := buildOriginalRequestURL(r)
+	return buildSSOAuthRedirect(ssoBase, originalURL)
+}
+
 // HandleAuthRouting handles the routing for ZorxAuth authentication provider.
 // It checks if the request is authenticated in the current site, if not, it redirects to the SSO login page
 func (ar *AuthRouter) HandleAuthRouting(w http.ResponseWriter, r *http.Request) error {
@@ -229,18 +248,13 @@ func (ar *AuthRouter) HandleAuthRouting(w http.ResponseWriter, r *http.Request) 
 
 	if !ar.RequestIsAuthenticatedInHost(w, r) {
 		// Not authenticated in the current site
-		if ar.Options.SSORedirectURL == "" {
+		redirectURL, err := ar.buildLoginRedirectURL(r)
+		if err != nil {
 			w.Header().Set("Content-Type", "text/html")
 			w.WriteHeader(http.StatusInternalServerError)
 			w.Write(invalidHTML)
-			return errors.New("SSO Redirect URL is not set")
+			return err
 		}
-		scheme := "http"
-		if r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https" {
-			scheme = "https"
-		}
-		originalURL := scheme + "://" + r.Host + r.RequestURI
-		redirectURL := ar.Options.SSORedirectURL + "?redirect=" + url.QueryEscape(originalURL)
 
 		// For AJAX requests, return 401 with JSON instead of redirecting
 		// This avoids CORS issues with cross-origin redirects
@@ -271,12 +285,13 @@ func (ar *AuthRouter) HandleAuthRouting(w http.ResponseWriter, r *http.Request) 
 			MaxAge:   -1,
 		})
 
-		scheme := "http"
-		if r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https" {
-			scheme = "https"
+		redirectURL, buildErr := ar.buildLoginRedirectURL(r)
+		if buildErr != nil {
+			w.Header().Set("Content-Type", "text/html")
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write(invalidHTML)
+			return buildErr
 		}
-		originalURL := scheme + "://" + r.Host + r.RequestURI
-		redirectURL := ar.Options.SSORedirectURL + "?redirect=" + url.QueryEscape(originalURL)
 
 		// For AJAX requests, return 401 with JSON instead of redirecting
 		if isAjaxRequest(r) {

--- a/src/mod/auth/sso/zorxauth/settings.go
+++ b/src/mod/auth/sso/zorxauth/settings.go
@@ -51,6 +51,15 @@ func (ar *AuthRouter) handleSettingsPOST(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	// Normalize host-only values (e.g. "auth.example.com") to absolute URLs so
+	// runtime redirects never treat them as relative paths on the protected host.
+	normalizedSSORedirectURL, normErr := ensureAbsoluteHTTPURL(ssoRedirectURL, "https")
+	if normErr != nil {
+		utils.SendErrorResponse(w, "SSO Redirect URL must be an absolute http(s) URL")
+		return
+	}
+	ssoRedirectURL = normalizedSSORedirectURL
+
 	ssoSessionSetURL, err := utils.PostPara(r, "ssoSessionSetURL")
 	if err != nil {
 		//Use the default value if not provided

--- a/src/mod/auth/sso/zorxauth/settings.go
+++ b/src/mod/auth/sso/zorxauth/settings.go
@@ -53,7 +53,9 @@ func (ar *AuthRouter) handleSettingsPOST(w http.ResponseWriter, r *http.Request)
 
 	// Normalize host-only values (e.g. "auth.example.com") to absolute URLs so
 	// runtime redirects never treat them as relative paths on the protected host.
-	normalizedSSORedirectURL, normErr := ensureAbsoluteHTTPURL(ssoRedirectURL, "https")
+	// Use the current request scheme (not a hardcoded https) so http-only
+	// deployments keep matching runtime redirect behavior.
+	normalizedSSORedirectURL, normErr := ensureAbsoluteHTTPURL(ssoRedirectURL, requestScheme(r))
 	if normErr != nil {
 		utils.SendErrorResponse(w, "SSO Redirect URL must be an absolute http(s) URL")
 		return

--- a/src/mod/auth/sso/zorxauth/urlutil.go
+++ b/src/mod/auth/sso/zorxauth/urlutil.go
@@ -1,0 +1,136 @@
+package zorxauth
+
+import (
+	"errors"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// requestScheme returns http or https for the incoming request, honoring X-Forwarded-Proto.
+func requestScheme(r *http.Request) string {
+	if r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https" {
+		return "https"
+	}
+	return "http"
+}
+
+// ensureAbsoluteHTTPURL makes sure raw is an absolute http(s) URL.
+// Host-only values such as "auth.example.com" (common when users omit the
+// protocol) are rewritten with fallbackScheme so http.Redirect does not treat
+// them as a relative path on the protected host (see #1108).
+func ensureAbsoluteHTTPURL(raw, fallbackScheme string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", errors.New("empty URL")
+	}
+	if strings.HasPrefix(raw, "/") {
+		return "", errors.New("URL must include a host")
+	}
+	if fallbackScheme != "http" && fallbackScheme != "https" {
+		fallbackScheme = "https"
+	}
+
+	if !strings.HasPrefix(raw, "http://") && !strings.HasPrefix(raw, "https://") {
+		raw = fallbackScheme + "://" + strings.TrimLeft(raw, "/")
+	}
+
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", err
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return "", errors.New("URL scheme must be http or https")
+	}
+	if u.Host == "" {
+		return "", errors.New("URL missing host")
+	}
+
+	// Keep path if present; drop a lone trailing slash so "?redirect=" appends cleanly
+	// when callers still concatenate. Prefer buildSSOAuthRedirect for new call sites.
+	if u.Path == "/" {
+		u.Path = ""
+	}
+	return u.String(), nil
+}
+
+// buildSSOAuthRedirect builds the SSO login URL with a redirect query parameter
+// pointing at the original protected resource.
+func buildSSOAuthRedirect(ssoBase, originalURL string) (string, error) {
+	u, err := url.Parse(ssoBase)
+	if err != nil {
+		return "", err
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return "", errors.New("SSO redirect URL must be absolute")
+	}
+	q := u.Query()
+	q.Set("redirect", originalURL)
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}
+
+// buildOriginalRequestURL reconstructs the absolute URL the user originally requested.
+// Nested "redirect" query values from a prior broken relative SSO hop are unwrapped
+// so a single successful login lands on the real resource instead of a nested URL.
+func buildOriginalRequestURL(r *http.Request) string {
+	scheme := requestScheme(r)
+	candidate := scheme + "://" + r.Host + r.URL.RequestURI()
+	return unwrapNestedRedirectTarget(candidate, r.Host)
+}
+
+// unwrapNestedRedirectTarget walks redirect= query values that still point at the
+// same host (the #1108 relative-redirect loop shape) and returns the innermost URL.
+// It only unwraps when the path looks like a host token (e.g. "/za.lan"), so a
+// legitimate app query such as "/oauth/callback?redirect=..." is left alone.
+func unwrapNestedRedirectTarget(candidate, host string) string {
+	const maxDepth = 8
+	for i := 0; i < maxDepth; i++ {
+		u, err := url.Parse(candidate)
+		if err != nil {
+			return candidate
+		}
+		if !strings.EqualFold(u.Hostname(), hostnameOnly(host)) {
+			return candidate
+		}
+
+		path := strings.Trim(u.Path, "/")
+		// Relative SSO loop uses the SSO hostname as a single path segment.
+		if path == "" || strings.Contains(path, "/") || !strings.Contains(path, ".") {
+			return candidate
+		}
+
+		redirectParam := u.Query().Get("redirect")
+		if redirectParam == "" {
+			return candidate
+		}
+		next, err := url.Parse(redirectParam)
+		if err != nil || next.Scheme == "" || next.Host == "" {
+			return candidate
+		}
+		if !strings.EqualFold(next.Hostname(), hostnameOnly(host)) {
+			return candidate
+		}
+		candidate = redirectParam
+	}
+	return candidate
+}
+
+func hostnameOnly(hostport string) string {
+	host, _, err := net.SplitHostPort(hostport)
+	if err != nil {
+		return hostport
+	}
+	return host
+}
+
+// ssoRedirectWouldLoop reports whether sending the browser to ssoBase would stay
+// on the same host as the protected request (misconfiguration / relative path).
+func ssoRedirectWouldLoop(ssoBase string, r *http.Request) bool {
+	u, err := url.Parse(ssoBase)
+	if err != nil || u.Host == "" {
+		return true
+	}
+	return strings.EqualFold(u.Hostname(), hostnameOnly(r.Host))
+}

--- a/src/mod/auth/sso/zorxauth/urlutil.go
+++ b/src/mod/auth/sso/zorxauth/urlutil.go
@@ -8,12 +8,28 @@ import (
 	"strings"
 )
 
-// requestScheme returns http or https for the incoming request, honoring X-Forwarded-Proto.
+// requestScheme returns http or https for the incoming request, honoring
+// X-Forwarded-Proto. The header is matched case-insensitively and only the
+// first value is used when proxies send a comma-separated list (e.g. "https, http").
 func requestScheme(r *http.Request) string {
-	if r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https" {
+	if r.TLS != nil {
 		return "https"
 	}
+	proto := r.Header.Get("X-Forwarded-Proto")
+	if proto != "" {
+		first := strings.TrimSpace(strings.Split(proto, ",")[0])
+		if strings.EqualFold(first, "https") {
+			return "https"
+		}
+	}
 	return "http"
+}
+
+// hasAbsoluteHTTPScheme reports whether raw already starts with http:// or
+// https://, ignoring scheme letter case (e.g. HTTPS://).
+func hasAbsoluteHTTPScheme(raw string) bool {
+	lower := strings.ToLower(raw)
+	return strings.HasPrefix(lower, "http://") || strings.HasPrefix(lower, "https://")
 }
 
 // ensureAbsoluteHTTPURL makes sure raw is an absolute http(s) URL.
@@ -32,7 +48,7 @@ func ensureAbsoluteHTTPURL(raw, fallbackScheme string) (string, error) {
 		fallbackScheme = "https"
 	}
 
-	if !strings.HasPrefix(raw, "http://") && !strings.HasPrefix(raw, "https://") {
+	if !hasAbsoluteHTTPScheme(raw) {
 		raw = fallbackScheme + "://" + strings.TrimLeft(raw, "/")
 	}
 
@@ -40,7 +56,7 @@ func ensureAbsoluteHTTPURL(raw, fallbackScheme string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if u.Scheme != "http" && u.Scheme != "https" {
+	if !strings.EqualFold(u.Scheme, "http") && !strings.EqualFold(u.Scheme, "https") {
 		return "", errors.New("URL scheme must be http or https")
 	}
 	if u.Host == "" {

--- a/src/mod/auth/sso/zorxauth/urlutil_test.go
+++ b/src/mod/auth/sso/zorxauth/urlutil_test.go
@@ -1,0 +1,180 @@
+package zorxauth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestEnsureAbsoluteHTTPURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		scheme  string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:   "host only gets https",
+			raw:    "za.lan",
+			scheme: "https",
+			want:   "https://za.lan",
+		},
+		{
+			name:   "host only uses request scheme",
+			raw:    "za.lan",
+			scheme: "http",
+			want:   "http://za.lan",
+		},
+		{
+			name:   "already absolute https preserved",
+			raw:    "https://auth.example.com",
+			scheme: "http",
+			want:   "https://auth.example.com",
+		},
+		{
+			name:   "path on SSO host preserved",
+			raw:    "https://auth.example.com/login",
+			scheme: "https",
+			want:   "https://auth.example.com/login",
+		},
+		{
+			name:   "trims whitespace and lone slash",
+			raw:    "  https://za.lan/  ",
+			scheme: "https",
+			want:   "https://za.lan",
+		},
+		{
+			name:    "empty rejected",
+			raw:     "   ",
+			scheme:  "https",
+			wantErr: true,
+		},
+		{
+			name:    "relative path rejected",
+			raw:     "/only-path",
+			scheme:  "https",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ensureAbsoluteHTTPURL(tt.raw, tt.scheme)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildSSOAuthRedirect(t *testing.T) {
+	got, err := buildSSOAuthRedirect("https://za.lan", "https://docs.local/docs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	u, err := url.Parse(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if u.Scheme != "https" || u.Host != "za.lan" {
+		t.Fatalf("unexpected base: %s", got)
+	}
+	if u.Query().Get("redirect") != "https://docs.local/docs" {
+		t.Fatalf("redirect query = %q", u.Query().Get("redirect"))
+	}
+
+	// Relative / host-only must fail so callers normalize first.
+	if _, err := buildSSOAuthRedirect("za.lan", "https://docs.local/"); err == nil {
+		t.Fatal("expected error for non-absolute SSO base")
+	}
+}
+
+func TestBuildOriginalRequestURLUnwrapsNestedRedirect(t *testing.T) {
+	nested := "https://docs.local/za.lan?redirect=" + url.QueryEscape(
+		"https://docs.local/za.lan?redirect="+url.QueryEscape("https://docs.local/"),
+	)
+	req := httptest.NewRequest(http.MethodGet, nested, nil)
+	req.Host = "docs.local"
+	req.Header.Set("X-Forwarded-Proto", "https")
+
+	got := buildOriginalRequestURL(req)
+	if got != "https://docs.local/" {
+		t.Fatalf("got %q, want https://docs.local/", got)
+	}
+}
+
+func TestBuildOriginalRequestURLKeepsAppRedirectQuery(t *testing.T) {
+	raw := "https://docs.local/oauth/callback?redirect=" + url.QueryEscape("https://oauth.example.com/done")
+	req := httptest.NewRequest(http.MethodGet, raw, nil)
+	req.Host = "docs.local"
+	req.Header.Set("X-Forwarded-Proto", "https")
+
+	got := buildOriginalRequestURL(req)
+	if got != raw {
+		t.Fatalf("got %q, want original app URL %q", got, raw)
+	}
+}
+
+func TestBuildLoginRedirectURL_HostOnlyConfig(t *testing.T) {
+	ar := &AuthRouter{
+		Options: &AuthRouterOptions{
+			SSORedirectURL: "za.lan",
+		},
+	}
+	req := httptest.NewRequest(http.MethodGet, "https://docs.local/readme", nil)
+	req.Host = "docs.local"
+	req.Header.Set("X-Forwarded-Proto", "https")
+
+	got, err := ar.buildLoginRedirectURL(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(got, "https://za.lan?") {
+		t.Fatalf("expected absolute SSO host, got %q", got)
+	}
+	u, err := url.Parse(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if u.Query().Get("redirect") != "https://docs.local/readme" {
+		t.Fatalf("redirect = %q", u.Query().Get("redirect"))
+	}
+}
+
+func TestBuildLoginRedirectURL_RejectsSameHostLoop(t *testing.T) {
+	ar := &AuthRouter{
+		Options: &AuthRouterOptions{
+			SSORedirectURL: "https://docs.local/sso",
+		},
+	}
+	req := httptest.NewRequest(http.MethodGet, "https://docs.local/", nil)
+	req.Host = "docs.local"
+	req.Header.Set("X-Forwarded-Proto", "https")
+
+	if _, err := ar.buildLoginRedirectURL(req); err == nil {
+		t.Fatal("expected same-host loop error")
+	}
+}
+
+func TestSSORedirectWouldLoop(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "https://docs.local/", nil)
+	req.Host = "docs.local"
+	if !ssoRedirectWouldLoop("https://docs.local/login", req) {
+		t.Fatal("expected loop")
+	}
+	if ssoRedirectWouldLoop("https://za.lan", req) {
+		t.Fatal("did not expect loop")
+	}
+}

--- a/src/mod/auth/sso/zorxauth/urlutil_test.go
+++ b/src/mod/auth/sso/zorxauth/urlutil_test.go
@@ -35,6 +35,12 @@ func TestEnsureAbsoluteHTTPURL(t *testing.T) {
 			want:   "https://auth.example.com",
 		},
 		{
+			name:   "uppercase HTTPS scheme preserved",
+			raw:    "HTTPS://auth.example.com",
+			scheme: "http",
+			want:   "https://auth.example.com",
+		},
+		{
 			name:   "path on SSO host preserved",
 			raw:    "https://auth.example.com/login",
 			scheme: "https",
@@ -176,5 +182,51 @@ func TestSSORedirectWouldLoop(t *testing.T) {
 	}
 	if ssoRedirectWouldLoop("https://za.lan", req) {
 		t.Fatal("did not expect loop")
+	}
+}
+
+func TestRequestSchemeHonorsForwardedProto(t *testing.T) {
+	tests := []struct {
+		name  string
+		proto string
+		want  string
+	}{
+		{name: "plain http", want: "http"},
+		{name: "exact https", proto: "https", want: "https"},
+		{name: "uppercase HTTPS", proto: "HTTPS", want: "https"},
+		{name: "comma list takes first", proto: "https, http", want: "https"},
+		{name: "comma list http first", proto: "http, https", want: "http"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "http://docs.local/", nil)
+			req.Host = "docs.local"
+			if tt.proto != "" {
+				req.Header.Set("X-Forwarded-Proto", tt.proto)
+			}
+			got := requestScheme(req)
+			if got != tt.want {
+				t.Fatalf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildLoginRedirectURL_HostOnlyUsesRequestHTTP(t *testing.T) {
+	ar := &AuthRouter{
+		Options: &AuthRouterOptions{
+			SSORedirectURL: "za.lan",
+		},
+	}
+	req := httptest.NewRequest(http.MethodGet, "http://docs.local/readme", nil)
+	req.Host = "docs.local"
+	// No X-Forwarded-Proto and no TLS -> http fallback must not force https.
+
+	got, err := ar.buildLoginRedirectURL(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(got, "http://za.lan?") {
+		t.Fatalf("expected http SSO host from request scheme, got %q", got)
 	}
 }

--- a/src/mod/auth/sso/zorxauth/zorxauth.go
+++ b/src/mod/auth/sso/zorxauth/zorxauth.go
@@ -20,13 +20,13 @@ import (
 	that only works in Zoraxy environment. It is ideal for lazy homelab sysadmins who don't want to setup a dedicated authentication
 	server just for a few services running in their homelab.
 
- 	SSORedirectURL is the URL of the SSO authentication endpoint, e.g. auth.example.com.
-	SSOSessionSetURL is the URL of the SSO session set endpoint, e.g. mysite.example.com/.wellknown/zorxauth/session/set,
+ 	SSORedirectURL is the URL of the SSO authentication endpoint, e.g. https://auth.example.com.
+	SSOSessionSetURL is the URL of the SSO session set endpoint, e.g. /.wellknown/zorxauth/session/set,
 	which will be called by the SSO endpoint after successful authentication to set the session ID in the AuthAgent.
 
 	The AuthAgent will redirect unauthenticated requests to this URL with a "redirect" query parameter
 	containing the original requested URL.
-	e.g. auth.example.com?redirect=http://mysite.example.com/protected/resource
+	e.g. https://auth.example.com?redirect=http://mysite.example.com/protected/resource
 
 	After successful authentication, the user will be redirected back to the original domain (mysite.example.com) to
 	the SSOSessionSetURL with the session ID and original redirect URL as query parameters, e.g.

--- a/src/web/components/sso.html
+++ b/src/web/components/sso.html
@@ -697,7 +697,15 @@
     $("#zorxAuthSettings").on("submit", function(event) {
         event.preventDefault();
 
-        const ssoRedirectURL = $('#zorxAuthSSORedirectURL').val();
+        const ssoRedirectURL = $('#zorxAuthSSORedirectURL').val().trim();
+        if (!ssoRedirectURL) {
+            msgbox('SSO Redirect URL is required', false);
+            return;
+        }
+        if (!/^https?:\/\//i.test(ssoRedirectURL)) {
+            msgbox('SSO Redirect URL must include the protocol (e.g. https://auth.example.com)', false);
+            return;
+        }
         const ssoSessionSetURL = $('#zorxAuthSSOSessionSetURL').val();
         const cookieName = $('#zorxAuthCookieName').val() || 'zr_xauth_session';
         const cookieDuration = parseInt($('#zorxAuthCookieDuration').val()) || 3600;


### PR DESCRIPTION
## Summary

Fixes #1108.

When Zoraxy Auth SSO Redirect URL was saved as a host only value like `za.lan` (no `http://` or `https://`), `http.Redirect` treated it as a relative path on the protected site. That produced loops such as:

`https://docs.local/za.lan?redirect=https://docs.local/za.lan?redirect=...`

## Changes

- Normalize host-only SSO Redirect URL values to absolute `http(s)` URLs when saving settings and when building the login redirect
- Build the SSO login URL with `url.Values` so existing query params stay intact
- Reject SSO Redirect URLs that resolve to the same host as the protected request (loop misconfig)
- Unwrap nested `#1108`-shaped relative redirect targets so a mid-loop browser URL can still land on the real resource after upgrade
- UI submit check requires an explicit protocol
- Unit tests for normalize, redirect build, unwrap, and same-host rejection

## AI assistance

This change was developed with AI assistance (Cursor / Grok). I reviewed the diff, ran the targeted tests below, and take responsibility for the patch.

## Evidence

```text
$ docker run --rm -e GOTOOLCHAIN=auto \
  -v ".../zoraxy-wt/1108-sso/src:/src:ro" -w /tmp golang:1.25 \
  bash -c "cp -a /src /tmp/zsrc && cd /tmp/zsrc && go get golang.org/x/net@v0.55.0 >/dev/null 2>&1; go test ./mod/auth/sso/zorxauth/ -count=1 -v"

=== RUN   TestEnsureAbsoluteHTTPURL
--- PASS: TestEnsureAbsoluteHTTPURL (0.00s)
=== RUN   TestBuildSSOAuthRedirect
--- PASS: TestBuildSSOAuthRedirect (0.00s)
=== RUN   TestBuildOriginalRequestURLUnwrapsNestedRedirect
--- PASS: TestBuildOriginalRequestURLUnwrapsNestedRedirect (0.00s)
=== RUN   TestBuildOriginalRequestURLKeepsAppRedirectQuery
--- PASS: TestBuildOriginalRequestURLKeepsAppRedirectQuery (0.00s)
=== RUN   TestBuildLoginRedirectURL_HostOnlyConfig
--- PASS: TestBuildLoginRedirectURL_HostOnlyConfig (0.00s)
=== RUN   TestBuildLoginRedirectURL_RejectsSameHostLoop
--- PASS: TestBuildLoginRedirectURL_RejectsSameHostLoop (0.00s)
=== RUN   TestSSORedirectWouldLoop
--- PASS: TestSSORedirectWouldLoop (0.00s)
PASS
ok  	imuslab.com/zoraxy/mod/auth/sso/zorxauth	0.005s
```

Checked `origin/v3.3.4` / open PR #1236 before coding: no SSO redirect logic fix there (only Forward Auth bulk vdir UI in `sso.html`).

## What was not tested

- Full live Zoraxy Auth gateway login against real reverse-proxy hosts on this machine (no local `docs.local` / `za.lan` DNS setup here). Behavior covered by unit tests that reproduce the host-only redirect construction from #1108.
