### PR TITLE
plugin store: add opt-in preview flag to plugin introspect

### DIFF
--- a/src/mod/plugins/zoraxy_plugin/zoraxy_plugin.go
+++ b/src/mod/plugins/zoraxy_plugin/zoraxy_plugin.go
@@ -61,16 +61,17 @@ the plugin shell return this payload as JSON and exit
 */
 type IntroSpect struct {
 	/* Plugin metadata */
-	ID            string     `json:"id"`             //Unique ID of your plugin, recommended using your own domain in reverse like com.yourdomain.pluginname
-	Name          string     `json:"name"`           //Name of your plugin
-	Author        string     `json:"author"`         //Author name of your plugin
-	AuthorContact string     `json:"author_contact"` //Author contact of your plugin, like email
-	Description   string     `json:"description"`    //Description of your plugin
-	URL           string     `json:"url"`            //URL of your plugin
-	Type          PluginType `json:"type"`           //Type of your plugin, Router(0) or Utilities(1)
-	VersionMajor  int        `json:"version_major"`  //Major version of your plugin
-	VersionMinor  int        `json:"version_minor"`  //Minor version of your plugin
-	VersionPatch  int        `json:"version_patch"`  //Patch version of your plugin
+	ID            string     `json:"id"`                //Unique ID of your plugin, recommended using your own domain in reverse like com.yourdomain.pluginname
+	Name          string     `json:"name"`              //Name of your plugin
+	Author        string     `json:"author"`            //Author name of your plugin
+	AuthorContact string     `json:"author_contact"`    //Author contact of your plugin, like email
+	Description   string     `json:"description"`       //Description of your plugin
+	URL           string     `json:"url"`               //URL of your plugin
+	Type          PluginType `json:"type"`              //Type of your plugin, Router(0) or Utilities(1)
+	VersionMajor  int        `json:"version_major"`     //Major version of your plugin
+	VersionMinor  int        `json:"version_minor"`     //Minor version of your plugin
+	VersionPatch  int        `json:"version_patch"`     //Patch version of your plugin
+	Preview       bool       `json:"preview,omitempty"` //Optional: mark this plugin as a preview / beta release, shown as a "Preview" tag in the plugin store
 
 	/*
 

--- a/src/web/components/appstore.html
+++ b/src/web/components/appstore.html
@@ -683,10 +683,15 @@
     return iconPath;
   }
 
-  //True when the app has no icon.png in its app folder, so the store index
-  //fell back to the generic placeholder icon (see IconPath handling in
-  //mod/plugins/store.go). Used to flag not-yet-polished apps as "Preview".
+  //True when the plugin opted in via the preview flag in its introspect, or
+  //when it has no icon.png in its app folder, so the store index fell back to
+  //the generic placeholder icon (see IconPath handling in mod/plugins/store.go).
+  //Used to flag not-yet-polished apps as "Preview".
   function asIsPreviewApp(app) {
+    let spec = app.PluginIntroSpect || {};
+    if (spec.preview === true) {
+      return true;
+    }
     return asGetIconSrc(app) == "img/plugin_icon.png";
   }
 


### PR DESCRIPTION
The app store derives the "Preview" tag solely from a missing icon.png (`asIsPreviewApp` in `appstore.html`), so a finished plugin without an icon is flagged as preview and a plugin can't deliberately mark itself as beta.

This adds an optional `preview` boolean to the plugin IntroSpect. When a plugin sets `preview: true` it shows the Preview tag in the store; the existing missing-icon fallback stays for backward compatibility.

- `zoraxy_plugin.go`: new `Preview bool` field (needed so the flag survives the JSON round-trip into the store frontend).
- `appstore.html`: `asIsPreviewApp` honors `spec.preview === true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)