### PR TITLE
plugin store: add opt-in preview flag to plugin introspect

### DIFF
--- a/docs/plugins/docs/2. Architecture/2. Introspect.md
+++ b/docs/plugins/docs/2. Architecture/2. Introspect.md
@@ -1,6 +1,6 @@
 # Introspect
 
-Last Update: 25/05/2025
+Last Update: 09/08/2026
 
 ---
 
@@ -13,16 +13,17 @@ The introspect structure is defined under the `zoraxy_plugin` library, where bot
 ```go
 type IntroSpect struct {
 	/* Plugin metadata */
-	ID            string     `json:"id"`             //Unique ID of your plugin, recommended using your own domain in reverse like com.yourdomain.pluginname
-	Name          string     `json:"name"`           //Name of your plugin
-	Author        string     `json:"author"`         //Author name of your plugin
-	AuthorContact string     `json:"author_contact"` //Author contact of your plugin, like email
-	Description   string     `json:"description"`    //Description of your plugin
-	URL           string     `json:"url"`            //URL of your plugin
-	Type          PluginType `json:"type"`           //Type of your plugin, Router(0) or Utilities(1)
-	VersionMajor  int        `json:"version_major"`  //Major version of your plugin
-	VersionMinor  int        `json:"version_minor"`  //Minor version of your plugin
-	VersionPatch  int        `json:"version_patch"`  //Patch version of your plugin
+	ID            string     `json:"id"`                //Unique ID of your plugin, recommended using your own domain in reverse like com.yourdomain.pluginname
+	Name          string     `json:"name"`              //Name of your plugin
+	Author        string     `json:"author"`            //Author name of your plugin
+	AuthorContact string     `json:"author_contact"`    //Author contact of your plugin, like email
+	Description   string     `json:"description"`       //Description of your plugin
+	URL           string     `json:"url"`               //URL of your plugin
+	Type          PluginType `json:"type"`              //Type of your plugin, Router(0) or Utilities(1)
+	VersionMajor  int        `json:"version_major"`     //Major version of your plugin
+	VersionMinor  int        `json:"version_minor"`     //Minor version of your plugin
+	VersionPatch  int        `json:"version_patch"`     //Patch version of your plugin
+	Preview       bool       `json:"preview,omitempty"` //Optional: mark this plugin as a preview / beta release, shown as a "Preview" tag in the plugin store
 
 	/*
 
@@ -62,6 +63,8 @@ type IntroSpect struct {
 
 
 The introspect provide Zoraxy the required information to start the plugin and how to interact with it.  For more details on what those capture settings are for, see "Capture Mode" section.
+
+The `preview` field is optional and defaults to `false`. Set it to `true` if your plugin is a preview or beta release, and the plugin store will show a "Preview" tag next to it. Plugins that do not ship an `icon.png` are tagged as preview regardless of this field.
 
 ---
 

--- a/docs/plugins/html/2. Architecture/2. Introspect.html
+++ b/docs/plugins/html/2. Architecture/2. Introspect.html
@@ -163,7 +163,7 @@
                 </h1>
                 <p>
                   <p class="ts-text">
-                    Last Update: 25/05/2025
+                    Last Update: 09/08/2026
                   </p>
                 </p>
                 <div class="ts-divider has-top-spaced-large"></div>
@@ -195,16 +195,17 @@
                 </p>
                 <pre><code class="language-go">type IntroSpect struct {
 	/* Plugin metadata */
-	ID            string     `json:&quot;id&quot;`             //Unique ID of your plugin, recommended using your own domain in reverse like com.yourdomain.pluginname
-	Name          string     `json:&quot;name&quot;`           //Name of your plugin
-	Author        string     `json:&quot;author&quot;`         //Author name of your plugin
-	AuthorContact string     `json:&quot;author_contact&quot;` //Author contact of your plugin, like email
-	Description   string     `json:&quot;description&quot;`    //Description of your plugin
-	URL           string     `json:&quot;url&quot;`            //URL of your plugin
-	Type          PluginType `json:&quot;type&quot;`           //Type of your plugin, Router(0) or Utilities(1)
-	VersionMajor  int        `json:&quot;version_major&quot;`  //Major version of your plugin
-	VersionMinor  int        `json:&quot;version_minor&quot;`  //Minor version of your plugin
-	VersionPatch  int        `json:&quot;version_patch&quot;`  //Patch version of your plugin
+	ID            string     `json:&quot;id&quot;`                //Unique ID of your plugin, recommended using your own domain in reverse like com.yourdomain.pluginname
+	Name          string     `json:&quot;name&quot;`              //Name of your plugin
+	Author        string     `json:&quot;author&quot;`            //Author name of your plugin
+	AuthorContact string     `json:&quot;author_contact&quot;`    //Author contact of your plugin, like email
+	Description   string     `json:&quot;description&quot;`       //Description of your plugin
+	URL           string     `json:&quot;url&quot;`               //URL of your plugin
+	Type          PluginType `json:&quot;type&quot;`              //Type of your plugin, Router(0) or Utilities(1)
+	VersionMajor  int        `json:&quot;version_major&quot;`     //Major version of your plugin
+	VersionMinor  int        `json:&quot;version_minor&quot;`     //Minor version of your plugin
+	VersionPatch  int        `json:&quot;version_patch&quot;`     //Patch version of your plugin
+	Preview       bool       `json:&quot;preview,omitempty&quot;` //Optional: mark this plugin as a preview / beta release, shown as a &quot;Preview&quot; tag in the plugin store
 
 	/*
 
@@ -242,6 +243,25 @@
 </code></pre>
                 <p>
                   The introspect provide Zoraxy the required information to start the plugin and how to interact with it.  For more details on what those capture settings are for, see &ldquo;Capture Mode&rdquo; section.
+                </p>
+                <p>
+                  The
+                  <span class="ts-text is-code">
+                    preview
+                  </span>
+                  field is optional and defaults to
+                  <span class="ts-text is-code">
+                    false
+                  </span>
+                  . Set it to
+                  <span class="ts-text is-code">
+                    true
+                  </span>
+                  if your plugin is a preview or beta release, and the plugin store will show a &ldquo;Preview&rdquo; tag next to it. Plugins that do not ship an
+                  <span class="ts-text is-code">
+                    icon.png
+                  </span>
+                  are tagged as preview regardless of this field.
                 </p>
                 <div class="ts-divider has-top-spaced-large"></div>
                 <h2 id="introspect-manual-triggering">

--- a/src/mod/plugins/zoraxy_plugin/zoraxy_plugin.go
+++ b/src/mod/plugins/zoraxy_plugin/zoraxy_plugin.go
@@ -61,16 +61,17 @@ the plugin shell return this payload as JSON and exit
 */
 type IntroSpect struct {
 	/* Plugin metadata */
-	ID            string     `json:"id"`             //Unique ID of your plugin, recommended using your own domain in reverse like com.yourdomain.pluginname
-	Name          string     `json:"name"`           //Name of your plugin
-	Author        string     `json:"author"`         //Author name of your plugin
-	AuthorContact string     `json:"author_contact"` //Author contact of your plugin, like email
-	Description   string     `json:"description"`    //Description of your plugin
-	URL           string     `json:"url"`            //URL of your plugin
-	Type          PluginType `json:"type"`           //Type of your plugin, Router(0) or Utilities(1)
-	VersionMajor  int        `json:"version_major"`  //Major version of your plugin
-	VersionMinor  int        `json:"version_minor"`  //Minor version of your plugin
-	VersionPatch  int        `json:"version_patch"`  //Patch version of your plugin
+	ID            string     `json:"id"`                //Unique ID of your plugin, recommended using your own domain in reverse like com.yourdomain.pluginname
+	Name          string     `json:"name"`              //Name of your plugin
+	Author        string     `json:"author"`            //Author name of your plugin
+	AuthorContact string     `json:"author_contact"`    //Author contact of your plugin, like email
+	Description   string     `json:"description"`       //Description of your plugin
+	URL           string     `json:"url"`               //URL of your plugin
+	Type          PluginType `json:"type"`              //Type of your plugin, Router(0) or Utilities(1)
+	VersionMajor  int        `json:"version_major"`     //Major version of your plugin
+	VersionMinor  int        `json:"version_minor"`     //Minor version of your plugin
+	VersionPatch  int        `json:"version_patch"`     //Patch version of your plugin
+	Preview       bool       `json:"preview,omitempty"` //Optional: mark this plugin as a preview / beta release, shown as a "Preview" tag in the plugin store
 
 	/*
 

--- a/src/web/components/appstore.html
+++ b/src/web/components/appstore.html
@@ -683,10 +683,15 @@
     return iconPath;
   }
 
-  //True when the app has no icon.png in its app folder, so the store index
-  //fell back to the generic placeholder icon (see IconPath handling in
-  //mod/plugins/store.go). Used to flag not-yet-polished apps as "Preview".
+  //True when the plugin opted in via the preview flag in its introspect, or
+  //when it has no icon.png in its app folder, so the store index fell back to
+  //the generic placeholder icon (see IconPath handling in mod/plugins/store.go).
+  //Used to flag not-yet-polished apps as "Preview".
   function asIsPreviewApp(app) {
+    let spec = app.PluginIntroSpect || {};
+    if (spec.preview === true) {
+      return true;
+    }
     return asGetIconSrc(app) == "img/plugin_icon.png";
   }
 


### PR DESCRIPTION
The app store derives the "Preview" tag solely from a missing icon.png, so a finished plugin without an icon is flagged as preview and a plugin cannot deliberately mark itself as preview.

Add an optional preview boolean to the plugin IntroSpect. The field is needed on the Go struct so the flag survives the JSON round-trip into the store frontend. The existing missing-icon fallback stays for backward compatibility.