### PR TITLE
fix(ui): reload access rule lists when the tab is opened

### DIFF
--- a/src/web/components/access.html
+++ b/src/web/components/access.html
@@ -1677,4 +1677,13 @@
     // Scope to this page's accordion only; .advanceSettings is reused by
     // other webmin components loaded dynamically via ajax.
     $("#accessAdvanceSettings").accordion();
+
+    //Bind on tab switch events
+    tabSwitchEventBind["access"] = function(){
+        //The lists are only loaded when this component is first rendered or
+        //when another access rule is picked. Anything that changed them in
+        //between - another session, or a plugin syncing IPs into a whitelist -
+        //stays invisible until a full page reload, so reload them here.
+        initBlackWhitelistTables();
+    };
 </script>


### PR DESCRIPTION
### What happens

Open Access Control, switch to another tab, come back: the black/whitelist tables still show what they showed the first time. Only a full page reload updates them.

### Why

`initBlackWhitelistTables()` is called from two places in `access.html` — when the component first renders, and from `handleSelectedAccessRuleChange()`. Nothing runs it when the tab is re-opened, so anything that changed the lists in between is invisible.

This shows up whenever the lists are changed outside that page: a second admin session, or a plugin keeping a whitelist in sync. In my case the entries are IPs resolved from DDNS names, so they move on their own every few minutes and the page is almost always out of date.

### The change

`index.html` already provides `tabSwitchEventBind`, and `status`, `httprp`, `vdir`, `rules`, `setroot`, `streamproxy` and `pluginContextWindow` all register there. This adds `access` alongside them. No new mechanism.

### Tested

Zoraxy 3.3.3 in Docker (arm64) running with `-dev` against this branch's `src/web`: changed a whitelisted IP from outside the page, switched to Status and back, the table showed the new value without a reload. Verified the same sequence still shows the stale value on an unpatched build.
