### PR TITLE
Add HttpOnly flag to OAuth2 SSO cookies

### DIFF
--- a/src/mod/auth/sso/oauth2/oauth2.go
+++ b/src/mod/auth/sso/oauth2/oauth2.go
@@ -349,7 +349,7 @@ func (ar *OAuth2Router) HandleOAuth2Auth(w http.ResponseWriter, r *http.Request)
 		if cookieExpiry.IsZero() || cookieExpiry.Before(time.Now()) {
 			cookieExpiry = time.Now().Add(time.Hour)
 		}
-		cookie := http.Cookie{Name: tokenCookie, Value: token.AccessToken, Path: "/", Expires: cookieExpiry}
+		cookie := http.Cookie{Name: tokenCookie, Value: token.AccessToken, Path: "/", Expires: cookieExpiry, HttpOnly: true}
 		if scheme == "https" {
 			cookie.Secure = true
 			cookie.SameSite = http.SameSiteLaxMode
@@ -357,7 +357,7 @@ func (ar *OAuth2Router) HandleOAuth2Auth(w http.ResponseWriter, r *http.Request)
 		w.Header().Add("Set-Cookie", cookie.String())
 
 		if ar.options.OAuth2CodeChallengeMethod == "PKCE" || ar.options.OAuth2CodeChallengeMethod == "PKCE_S256" {
-			cookie := http.Cookie{Name: verifierCookie, Value: "", Path: "/", Expires: time.Now().Add(-time.Hour * 1)}
+			cookie := http.Cookie{Name: verifierCookie, Value: "", Path: "/", Expires: time.Now().Add(-time.Hour * 1), HttpOnly: true}
 			if scheme == "https" {
 				cookie.Secure = true
 				cookie.SameSite = http.SameSiteLaxMode
@@ -405,7 +405,7 @@ func (ar *OAuth2Router) HandleOAuth2Auth(w http.ResponseWriter, r *http.Request)
 		state := url.QueryEscape(reqUrl)
 		var url string
 		if ar.options.OAuth2CodeChallengeMethod == "PKCE" || ar.options.OAuth2CodeChallengeMethod == "PKCE_S256" {
-			cookie := http.Cookie{Name: verifierCookie, Value: oauth2.GenerateVerifier(), Path: "/", Expires: time.Now().Add(time.Hour * 1)}
+			cookie := http.Cookie{Name: verifierCookie, Value: oauth2.GenerateVerifier(), Path: "/", Expires: time.Now().Add(time.Hour * 1), HttpOnly: true}
 			if scheme == "https" {
 				cookie.Secure = true
 				cookie.SameSite = http.SameSiteLaxMode


### PR DESCRIPTION
The OAuth2 forward auth handler stores the raw access token in the `z-token` cookie and the PKCE verifier in `z-verifier`, but neither cookie sets the `HttpOnly` flag. To reproduce, sign in through the OAuth2 provider on any proxied host and run `document.cookie` in the browser console: the access token is readable. As a result, an XSS in any application behind the proxy can exfiltrate the token and reuse it for the whole SSO session.

This adds `HttpOnly: true` to the three cookie literals in `HandleOAuth2Auth` (token cookie, verifier cookie and the verifier clear-out cookie, the last one only for consistency of attributes). These cookies are only consumed server side, so the OAuth2 flow itself is unchanged.
