### PR TITLE
Bind OAuth2 SSO sessions to tokens issued by Zoraxy

### DIFF
--- a/src/mod/auth/sso/oauth2/oauth2.go
+++ b/src/mod/auth/sso/oauth2/oauth2.go
@@ -2,6 +2,8 @@ package oauth2
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -35,6 +37,7 @@ type OAuth2RouterOptions struct {
 	Logger                       *logger.Logger
 	Database                     *database.Database
 	OAuth2ConfigCache            *ttlcache.Cache[string, *oauth2.Config]
+	OAuth2SessionStore           *ttlcache.Cache[string, *oauth2.Token]
 }
 
 type OIDCDiscoveryDocument struct {
@@ -86,6 +89,11 @@ func NewOAuth2Router(options *OAuth2RouterOptions) *OAuth2Router {
 		ttlcache.WithTTL[string, *oauth2.Config](*options.OAuth2ConfigurationCacheTime),
 	)
 	go options.OAuth2ConfigCache.Start()
+
+	options.OAuth2SessionStore = ttlcache.New[string, *oauth2.Token](
+		ttlcache.WithDisableTouchOnHit[string, *oauth2.Token](),
+	)
+	go options.OAuth2SessionStore.Start()
 
 	return ar
 }
@@ -203,6 +211,7 @@ func (ar *OAuth2Router) handleSetOAuthSettingsPOST(w http.ResponseWriter, r *htt
 
 	// Flush caches
 	ar.options.OAuth2ConfigCache.DeleteAll()
+	ar.options.OAuth2SessionStore.DeleteAll()
 
 	utils.SendOK(w)
 }
@@ -349,7 +358,18 @@ func (ar *OAuth2Router) HandleOAuth2Auth(w http.ResponseWriter, r *http.Request)
 		if cookieExpiry.IsZero() || cookieExpiry.Before(time.Now()) {
 			cookieExpiry = time.Now().Add(time.Hour)
 		}
-		cookie := http.Cookie{Name: tokenCookie, Value: token.AccessToken, Path: "/", Expires: cookieExpiry, HttpOnly: true}
+		//Store the token server side and only hand out an opaque session id, so the
+		//cookie value cannot be swapped for a token issued to another OAuth2 client
+		sessionIdBytes := make([]byte, 32)
+		if _, err := rand.Read(sessionIdBytes); err != nil {
+			ar.options.Logger.PrintAndLog("OAuth2", "Failed to generate session id", err)
+			w.WriteHeader(500)
+			return errors.New("internal server error")
+		}
+		sessionId := base64.RawURLEncoding.EncodeToString(sessionIdBytes)
+		ar.options.OAuth2SessionStore.Set(sessionId, token, time.Until(cookieExpiry))
+
+		cookie := http.Cookie{Name: tokenCookie, Value: sessionId, Path: "/", Expires: cookieExpiry, HttpOnly: true}
 		if scheme == "https" {
 			cookie.Secure = true
 			cookie.SameSite = http.SameSiteLaxMode
@@ -382,11 +402,12 @@ func (ar *OAuth2Router) HandleOAuth2Auth(w http.ResponseWriter, r *http.Request)
 	unauthorized := false
 	cookie, err := r.Cookie(tokenCookie)
 	if err == nil {
-		if cookie.Value == "" {
+		session := ar.options.OAuth2SessionStore.Get(cookie.Value)
+		if cookie.Value == "" || session == nil {
 			unauthorized = true
 		} else {
 			ctx := context.Background()
-			client := oauthConfig.Client(ctx, &oauth2.Token{AccessToken: cookie.Value})
+			client := oauthConfig.Client(ctx, session.Value())
 			req, err := client.Get(ar.options.OAuth2UserInfoUrl)
 			if err != nil {
 				ar.options.Logger.PrintAndLog("OAuth2", "Failed to get user info", err)

--- a/src/mod/auth/sso/oauth2/oauth2.go
+++ b/src/mod/auth/sso/oauth2/oauth2.go
@@ -349,7 +349,7 @@ func (ar *OAuth2Router) HandleOAuth2Auth(w http.ResponseWriter, r *http.Request)
 		if cookieExpiry.IsZero() || cookieExpiry.Before(time.Now()) {
 			cookieExpiry = time.Now().Add(time.Hour)
 		}
-		cookie := http.Cookie{Name: tokenCookie, Value: token.AccessToken, Path: "/", Expires: cookieExpiry}
+		cookie := http.Cookie{Name: tokenCookie, Value: token.AccessToken, Path: "/", Expires: cookieExpiry, HttpOnly: true}
 		if scheme == "https" {
 			cookie.Secure = true
 			cookie.SameSite = http.SameSiteLaxMode
@@ -357,7 +357,7 @@ func (ar *OAuth2Router) HandleOAuth2Auth(w http.ResponseWriter, r *http.Request)
 		w.Header().Add("Set-Cookie", cookie.String())
 
 		if ar.options.OAuth2CodeChallengeMethod == "PKCE" || ar.options.OAuth2CodeChallengeMethod == "PKCE_S256" {
-			cookie := http.Cookie{Name: verifierCookie, Value: "", Path: "/", Expires: time.Now().Add(-time.Hour * 1)}
+			cookie := http.Cookie{Name: verifierCookie, Value: "", Path: "/", Expires: time.Now().Add(-time.Hour * 1), HttpOnly: true}
 			if scheme == "https" {
 				cookie.Secure = true
 				cookie.SameSite = http.SameSiteLaxMode
@@ -405,7 +405,7 @@ func (ar *OAuth2Router) HandleOAuth2Auth(w http.ResponseWriter, r *http.Request)
 		state := url.QueryEscape(reqUrl)
 		var url string
 		if ar.options.OAuth2CodeChallengeMethod == "PKCE" || ar.options.OAuth2CodeChallengeMethod == "PKCE_S256" {
-			cookie := http.Cookie{Name: verifierCookie, Value: oauth2.GenerateVerifier(), Path: "/", Expires: time.Now().Add(time.Hour * 1)}
+			cookie := http.Cookie{Name: verifierCookie, Value: oauth2.GenerateVerifier(), Path: "/", Expires: time.Now().Add(time.Hour * 1), HttpOnly: true}
 			if scheme == "https" {
 				cookie.Secure = true
 				cookie.SameSite = http.SameSiteLaxMode


### PR DESCRIPTION
The OAuth2 authorization check takes the `z-token` cookie value as a bearer token and calls the provider's UserInfo endpoint with it. Any HTTP 200 response is accepted as authorized. Nothing ties that token to the OAuth2 client Zoraxy is configured with, so a token issued by the same identity provider for a different client passes the check as well.

This matters as soon as the provider serves more than one application: a token that legitimately belongs to another client is accepted by Zoraxy. The raw token is also handed on to upstream applications together with the remaining cookies.

This change stores the token server side in a TTL cache and puts an opaque random session id in the cookie instead. Only tokens obtained through Zoraxy's own code exchange can be used, and the token no longer travels to upstream applications. The per-request UserInfo call is kept, so revoked tokens still end the session.

Behaviour changes worth considering before merging:

- SSO sessions are held in memory, so restarting Zoraxy signs users out.
- Upstream applications no longer receive the access token in `z-token`.
- Saving the OAuth2 settings flushes existing sessions.

An alternative approach would be to validate the `aud` claim of an ID token against the configured client id via JWKS. That keeps the check stateless, but it adds a JWT dependency and requires the provider to issue ID tokens. Happy to rework it that way if you prefer.

Builds on #1262.
