### PR TITLE
Fix client IP detection for IPv6 clients in forward auth

### DIFF
--- a/src/mod/auth/sso/forward/util.go
+++ b/src/mod/auth/sso/forward/util.go
@@ -125,14 +125,22 @@ func stringInSliceFold(needle string, haystack []string) bool {
 }
 
 func rSetIPHeader(r, req *http.Request, headers ...string) {
-	if r.RemoteAddr == "" || len(headers) == 0 {
+	if len(headers) == 0 {
 		return
 	}
 
-	before, _, _ := strings.Cut(r.RemoteAddr, ":")
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		host = r.RemoteAddr
+	}
 
-	ip := net.ParseIP(before)
+	ip := net.ParseIP(host)
 	if ip == nil {
+		// We should never leave a client supplied value in these headers when the address cannot be determined.
+		for _, header := range headers {
+			req.Header.Del(header)
+		}
+
 		return
 	}
 

--- a/src/mod/auth/sso/forward/util_test.go
+++ b/src/mod/auth/sso/forward/util_test.go
@@ -215,3 +215,37 @@ func TestHeaderCopyIncluded(t *testing.T) {
 		})
 	}
 }
+
+func TestRSetIPHeader(t *testing.T) {
+	testCases := []struct {
+		name       string
+		remoteAddr string
+		supplied   string
+		expected   string
+	}{
+		{"ShouldHandleIPv4", "10.0.0.1:54321", "", "10.0.0.1"},
+		{"ShouldHandleIPv6", "[2a01:4f8::1]:54321", "", "2a01:4f8::1"},
+		{"ShouldHandleIPv6WithoutPort", "2a01:4f8::1", "", "2a01:4f8::1"},
+		{"ShouldOverwriteClientSuppliedIPv4", "10.0.0.1:54321", "10.2.45.5", "10.0.0.1"},
+		{"ShouldOverwriteClientSuppliedIPv6", "[2a01:4f8::1]:54321", "10.2.45.5", "2a01:4f8::1"},
+		{"ShouldDropClientSuppliedOnUnparsableAddress", "not-an-address", "10.2.45.5", ""},
+		{"ShouldDropClientSuppliedOnEmptyAddress", "", "10.2.45.5", ""},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &http.Request{RemoteAddr: tc.remoteAddr}
+			req := &http.Request{Header: http.Header{}}
+
+			if tc.supplied != "" {
+				req.Header.Set(HeaderXForwardedFor, tc.supplied)
+				req.Header.Set(HeaderXOriginalIP, tc.supplied)
+			}
+
+			rSetIPHeader(r, req, HeaderXForwardedFor, HeaderXOriginalIP)
+
+			assert.Equal(t, tc.expected, req.Header.Get(HeaderXForwardedFor))
+			assert.Equal(t, tc.expected, req.Header.Get(HeaderXOriginalIP))
+		})
+	}
+}


### PR DESCRIPTION
`rSetIPHeader` in the forward auth module splits `r.RemoteAddr` at the first colon before parsing it. For an IPv6 client the remote address looks like `[2a01:4f8::1]:54321`, so the cut yields `[2a01`, `net.ParseIP` fails and the function returns without setting `X-Forwarded-For`. At that point `HandleAuthProviderRouting` has already copied the client's headers into the authorization request (all of them, in the default configuration with no included headers set), so an `X-Forwarded-For` header supplied by the client survives untouched. Over IPv6, the client decides which IP the authorization server sees.

To reproduce: put a host behind forward auth with a provider that makes IP-based decisions, for example tinyauth with an IP bypass rule for `10.2.45.5`, and send the same request with `X-Forwarded-For: 10.2.45.5` twice. Over IPv4 the provider sees the real address and answers 401. Over IPv6 it sees `10.2.45.5`, logs `IP is in bypass list, skipping authentication`, and the request reaches the protected backend with a 200. Confirmed on v3.3.3, v3.3.4 and current main.

This change parses the address with `net.SplitHostPort`, the same way `GetRequesterIPUntrusted` in `mod/netutils/ipmatch.go` already handles it, with a fallback to the raw value for a portless address. When no IP can be determined at all, the headers are now deleted instead of being left as they arrived, so a client-supplied value can never travel to the authorization provider. Behaviour for IPv4 clients is unchanged.

The deprecated Authelia module (`src/mod/auth/sso/deprecated/authelia/authelia.go`) contains the same colon-split pattern. I left it untouched to keep this diff small, but I can patch it the same way if you want.
